### PR TITLE
Fix Motor version, let it pull in PyMongo

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,12 +16,11 @@ with open('HISTORY.rst', 'rb') as history_file:
 
 requirements = [
     "marshmallow>=2.6.0",
-    "pymongo"  # needed for bson module
 ]
 
 test_requirements = [
     "txmongo",
-    "motor>=0.7.4"
+    "motor>=0.6.2"
 ]
 
 setup(


### PR DESCRIPTION
Motor already depends on a specific PyMongo version, better to depend on Motor instead of adding a separate dependency link to PyMongo.