### PR TITLE
Add pre_commit and post_commit hooks

### DIFF
--- a/umongo/document.py
+++ b/umongo/document.py
@@ -228,11 +228,11 @@ class DocumentImplementation(Implementation, metaclass=MetaDocumentImplementatio
 
     def commit(self, io_validate_all=False, conditions=None):
 
-        self.pre_commit(io_validate_all=False, conditions=None)
+        self.pre_commit(io_validate_all=False, conditions=conditions)
 
-        self._commit(io_validate_all=True, conditions=None)
+        self._commit(io_validate_all=True, conditions=conditions)
 
-        self.post_commit(io_validate_all=False, conditions=None)
+        self.post_commit(io_validate_all=False, conditions=conditions)
 
     def pre_commit(self, io_validate_all=False, conditions=None):
         pass

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -226,6 +226,20 @@ class DocumentImplementation(Implementation, metaclass=MetaDocumentImplementatio
         """
         self._data.clear_modified()
 
+    def commit(self, io_validate_all=False, conditions=None):
+
+        self.pre_commit(io_validate_all=False, conditions=None)
+
+        self._commit(io_validate_all=True, conditions=None)
+
+        self.post_commit(io_validate_all=False, conditions=None)
+
+    def pre_commit(self, io_validate_all=False, conditions=None):
+        pass
+
+    def post_commit(self, io_validate_all=False, conditions=None):
+        pass
+
     # Data-proxy accessor shortcuts
 
     def __getitem__(self, name):

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -78,7 +78,7 @@ class MotorAsyncIODocument(DocumentImplementation):
         self._data.from_mongo(ret)
 
     @asyncio.coroutine
-    def commit(self, io_validate_all=False, conditions=None):
+    def _commit(self, io_validate_all=False, conditions=None):
         """
         Commit the document in database.
         If the document doesn't already exist it will be inserted, otherwise

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -63,7 +63,7 @@ class PyMongoDocument(DocumentImplementation):
         self._data = DataProxy(self.schema)
         self._data.from_mongo(ret)
 
-    def commit(self, io_validate_all=False, conditions=None):
+    def _commit(self, io_validate_all=False, conditions=None):
         """
         Commit the document in database.
         If the document doesn't already exist it will be inserted, otherwise

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -36,7 +36,7 @@ class TxMongoDocument(DocumentImplementation):
         self._data.from_mongo(ret)
 
     @inlineCallbacks
-    def commit(self, io_validate_all=False, conditions=None):
+    def _commit(self, io_validate_all=False, conditions=None):
         """
         Commit the document in database.
         If the document doesn't already exist it will be inserted, otherwise


### PR DESCRIPTION
This draft illustrates the hook feature we've been talking about by email.

It works in my simple use case. There is one limitation, though: I don't know how create a `pre_commit` method in an inheritable class and override it in a child class calling `super()` to get to the common part. I get an error:

    TypeError: super(type, obj): obj must be an instance or subtype of type

As you said, this is most likely due to the Template/Implementation duality: the methods are in `DocumentImplementation` but then I override them in `DocumentTemplate`.

I'd like to rework this to a better design, but I'd need a hint, as I don't know how to sort this out.

Did you have something else in mind?
