### PR TITLE
Set a field to None removes it from DB

### DIFF
--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -138,6 +138,8 @@ class DataProxy:
         field = self._fields[name]
         name = field.attribute or name
         value = field._deserialize(value, name, None)
+        if value is None:
+            value = missing
         field._validate(value)
         self._data[name] = value
         self._mark_as_modified(name)


### PR DESCRIPTION
I'm using this patch to allow the user to remove a field by setting it to `None`.

Basically, when an object attribute is set to `None`, rather than getting a validation error, the value is changed into `missing` and the field is removed.

It seems to make sense to me and it works on my use case but it's hardly tested, so there may be corner cases I didn't think of.

Is there already a clean way to do that I didn't know about? If not, is it a feature you'd find useful?