### PR TITLE
Point field

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,8 @@ with open('HISTORY.rst', 'rb') as history_file:
     history = history_file.read().decode('utf8')
 
 requirements = [
-    "marshmallow>=2.6.0"
+    "marshmallow>=2.6.0",
+    "geojson>=1.3.1",
 ]
 
 setup(

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -239,7 +239,7 @@ class PointField(BaseField, ma_fields.Field):
         return geojson.dumps(obj)
 
     def _deserialize_from_mongo(self, value):
-        return geojson.loads(value)
+        return geojson.GeoJSON.to_instance(value)
 
 
 class ReferenceField(ObjectIdField):

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -235,9 +235,6 @@ class PointField(BaseField, ma_fields.Field):
         except ValueError:
             raise ValidationError(_('Invalid Point.'))
 
-    def _serialize_to_mongo(self, obj):
-        return geojson.dumps(obj)
-
     def _deserialize_from_mongo(self, value):
         return geojson.GeoJSON.to_instance(value)
 


### PR DESCRIPTION
PointField proposal.

MongoDB stores geo data conforming to GeoJSON standard (see http://blog.mongodb.org/post/50984169045/new-geo-features-in-mongodb-24), which is inplemented in [python-geojson](https://github.com/frewsxcv/python-geojson), so we don't have to recreate the [|de]serializers.

Here again, just a draft. If you like it, I may add tests/docs.
