### PR TITLE
Add reset_missings parameter to DocumentImplementation's update method

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -404,6 +404,12 @@ class TestDataProxy(BaseTest):
         assert d.get('c') == 3
         assert d.get('d') == 41
         assert set(['e']) == d._modified_data
-        # With reset_missings: exception raised
-        with pytest.raises(ValidationError):
-            d.update({'d': 41}, reset_missings=True)
+        # With reset_missings
+        # No exception raised for missing required value
+        d.clear_modified()
+        d.update({'d': 41}, reset_missings=True)
+        assert d.get('a') == missing
+        assert d.get('b') == 69
+        assert d.get('c') == 3
+        assert d.get('d') == 41
+        assert set(['a', 'b', 'e']) == d._modified_data

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -84,8 +84,7 @@ class BaseDataProxy:
     def update(self, data, reset_missings=False):
 
         # Use marshmallow partial load to skip required checks
-        # unless reset_missings is True
-        loaded_data, err = self.schema.load(data, partial=(not reset_missings))
+        loaded_data, err = self.schema.load(data, partial=True)
         if err:
             raise ValidationError(err)
         self._data.update(loaded_data)

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -82,11 +82,6 @@ class DataProxy:
 
     def update(self, data, schema=None, reset_missings=False):
         schema = schema or self._schema
-        # Always use marshmallow partial load to skip required checks
-        loaded_data, err = schema.load(data, partial=True)
-        if err:
-            raise ValidationError(err)
-        self._data.update(loaded_data)
 
         # Set missing values to missing
         if reset_missings:
@@ -97,6 +92,11 @@ class DataProxy:
                 self._data[key] = missing
                 self._mark_as_modified(key)
 
+        # Always use marshmallow partial load to skip required checks
+        loaded_data, err = schema.load(data, partial=True)
+        if err:
+            raise ValidationError(err)
+        self._data.update(loaded_data)
         for key in loaded_data:
             self._mark_as_modified(key)
 

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -98,11 +98,12 @@ class BaseDataProxy:
         # Delete missing fields unless dump_only or with a default value
         if reset_missings:
             deletable_fields = set(
-                [k for k, v in self.schema.fields.items()
+                [k for k, v in self._fields.items()
                  if not v.dump_only and v.missing is missing])
             missing_keys = deletable_fields - set(data)
             for key in missing_keys:
                 self.delete(key)
+                self.not_loaded_fields.discard(self._fields[key])
 
     def load(self, data, partial=False):
         # Always use marshmallow partial load to skip required checks

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -89,7 +89,7 @@ class DataProxy:
         schema = schema or self._schema
 
         # Use marshmallow partial load to skip required checks
-        # unless reset_missings is True
+        # unless reset_missings is True
         loaded_data, err = schema.load(data, partial=(not reset_missings))
         if err:
             raise ValidationError(err)

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -95,6 +95,7 @@ class DataProxy:
             missing_keys = loadable_fields - set(data)
             for key in missing_keys:
                 self._data[key] = missing
+                self._mark_as_modified(key)
 
         for key in loaded_data:
             self._mark_as_modified(key)

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -203,13 +203,15 @@ class DocumentImplementation(Implementation, metaclass=MetaDocumentImplementatio
                                   ' using update')
         return self._data.to_mongo(update=update)
 
-    def update(self, data, schema=None):
+    def update(self, data, schema=None, reset_missings=False):
         """
         Update the document with the given data
 
         :param schema: use this schema for the load instead of the default one
+        :param reset_missings: if True, all loadable fields in schema missing
+                               in data are removed from document
         """
-        return self._data.update(data, schema=schema)
+        return self._data.update(data, schema=schema, reset_missings=reset_missings)
 
     def dump(self, schema=None):
         """

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -76,6 +76,9 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
     def dump(self):
         return self._data.dump()
 
+    def update(self, data, schema=None, reset_missings=False):
+        return self._data.update(data, schema=schema, reset_missings=reset_missings)
+
     # Data-proxy accessor shortcuts
 
     def __getitem__(self, name):


### PR DESCRIPTION
Implementation proposal for the `reset_missings` feature.

Removes value from document if loadable in the Schema but missing in input data.

``` python
user = User(name='Hannibal', team="A-Team")
user.update({'name': 'Looping'})
assert user.team == "A-Team"
user.update({'name': 'Chuck Norris'}, reset_missings=True)
assert user.team == None
```
