### PR TITLE
Fix $unset syntax in `_to_mongo_update`

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -69,7 +69,7 @@ class TestDataProxy(BaseTest):
         assert d.to_mongo(update=True) is None
         d.set('a', 3)
         d.delete('b')
-        assert d.to_mongo(update=True) == {'$set': {'a': 3}, '$unset': ['in_mongo_b']}
+        assert d.to_mongo(update=True) == {'$set': {'a': 3}, '$unset': {'in_mongo_b': ''}}
         d.clear_modified()
         assert d.to_mongo(update=True) is None
         assert d.to_mongo() == {'a': 3}
@@ -126,9 +126,9 @@ class TestDataProxy(BaseTest):
         d.load({'a': 1, 'b': 2})
         d.delete('b')
         assert d.to_mongo() == {'a': 1}
-        assert d.to_mongo(update=True) == {'$unset': ['in_mongo_b']}
+        assert d.to_mongo(update=True) == {'$unset': {'in_mongo_b': ''}}
         d.delete('a')
-        assert d.to_mongo(update=True) == {'$unset': ['a', 'in_mongo_b']}
+        assert d.to_mongo(update=True) == {'$unset': {'a': '', 'in_mongo_b': ''}}
 
         with pytest.raises(KeyError):
             d.delete('in_mongo_b')
@@ -191,7 +191,7 @@ class TestDataProxy(BaseTest):
         assert d.to_mongo(update=True) == {'$set': {'in_mongo_b': 3}}
         assert d.get_by_mongo_name('in_mongo_b') == 3
         d.delete_by_mongo_name('in_mongo_b')
-        assert d.to_mongo(update=True) == {'$unset': ['in_mongo_b']}
+        assert d.to_mongo(update=True) == {'$unset': {'in_mongo_b': ''}}
 
     def test_set_to_missing_fields(self):
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -177,7 +177,7 @@ class TestFields(BaseTest):
         assert d.to_mongo(update=True) is None
 
         del embedded.a
-        assert embedded.to_mongo(update=True) == {'$unset': ['in_mongo_a']}
+        assert embedded.to_mongo(update=True) == {'$unset': {'in_mongo_a': ''}}
         assert d.to_mongo(update=True) == {'$set': {'in_mongo_embedded': {'b': 2}}}
 
         d.set('embedded', MyEmbeddedDocument(a=4))
@@ -257,7 +257,7 @@ class TestFields(BaseTest):
         d.clear_modified()
         d.get('list').clear()
         assert d.dump() == {'list': []}
-        assert d.to_mongo(update=True) == {'$unset': ['in_mongo_list']}
+        assert d.to_mongo(update=True) == {'$unset': {'in_mongo_list': ''}}
 
         d.set('list', [1, 2, 3])
         d.clear_modified()

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -58,7 +58,7 @@ class DataProxy:
         if set_data:
             mongo_data['$set'] = set_data
         if unset_data:
-            mongo_data['$unset'] = sorted(unset_data)
+            mongo_data['$unset'] = {k: "" for k in unset_data}
         return mongo_data or None
 
     def from_mongo(self, data, partial=False):


### PR DESCRIPTION
I'm having issues unsetting fields. It it likely I misunderstood the whole thing, but from what I understand, `_to_mongo_update` generates `$unset` operations as (see [here](https://github.com/Scille/umongo/blob/master/tests/test_data_proxy.py#L131) for instance):

    {'$unset': ['a', 'b']}

This generates errors:

    "Modifiers operate on fields but we found a Array instead. For example: {$mod: {<field>: ...}} not {$unset: [ \"a\", \"b\" ]}"

Indeed, the [docs](https://docs.mongodb.com/manual/reference/operator/update/unset/) indicate the expected syntax is:

    $unset: { quantity: "", instock: "" }

I'm a bit surprised no one ever hit this before, which makes me think I might be wrong.

Anyway, here's a fix proposal to illustrate the idea. Obviously, it breaks the tests. I'd rather you validate the idea before modifying the tests.

Also, I don't understand the use of `sorted` in the original code.
