### PR TITLE
fields: _serialize to None if value is None

### DIFF
--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -249,6 +249,8 @@ class ReferenceField(ObjectIdField):
         return self._document_cls
 
     def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
         return super()._serialize(value.pk, attr, obj)
 
     def _deserialize(self, value, attr, data):
@@ -300,6 +302,8 @@ class GenericReferenceField(BaseField):
         self._document_implementation_cls = DocumentImplementation
 
     def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
         return {'id': str(value.pk), 'cls': value.document_cls.__name__}
 
     def _deserialize(self, value, attr, data):
@@ -379,6 +383,8 @@ class EmbeddedField(BaseField, ma_fields.Nested):
         return self._embedded_document_cls
 
     def _serialize(self, value, attr, obj):
+        if value is None:
+            return None
         return value.dump()
 
     def _deserialize(self, value, attr, data):


### PR DESCRIPTION
I stumbled upon this while trying to use a Schema to serialize a Document using

    schema.dump(document)

(That use case we'd like to support but currently don't really.)

I'm not sure this can happen in the supported use case (use of Schema to serialize data_proxy)

    document.dump()

but I saw the same mechanism in `ObjectIdField` and in most if not all Marshmallow fields.

I assume it can't hurt...

