### PR TITLE
Add update method to EmbeddedDocument

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -197,6 +197,12 @@ class TestFields(BaseTest):
         assert embedded_doc['a'] == 1
         assert embedded_doc['b'] == 2
 
+        embedded_doc.clear_modified()
+        embedded_doc.update({'b': 42})
+        assert embedded_doc.is_modified()
+        assert embedded_doc.a == 1
+        assert embedded_doc.b == 42
+
         with pytest.raises(ValidationError):
             MyEmbeddedDocument(in_mongo_a=1, b=2)
 

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -210,7 +210,7 @@ class DocumentImplementation(Implementation, metaclass=MetaDocumentImplementatio
 
         :param schema: use this schema for the load instead of the default one
         """
-        return self._data.update(data, schema=schema)
+        self._data.update(data, schema=schema)
 
     def dump(self, schema=None):
         """

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -73,6 +73,9 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
     def to_mongo(self, update=False):
         return self._data.to_mongo(update=update)
 
+    def update(self, data, schema=None):
+        return self._data.update(data, schema=schema)
+
     def dump(self, schema=None):
         return self._data.dump(schema=schema)
 

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -73,8 +73,8 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
     def to_mongo(self, update=False):
         return self._data.to_mongo(update=update)
 
-    def dump(self):
-        return self._data.dump()
+    def dump(self, schema=None):
+        return self._data.dump(schema=schema)
 
     # Data-proxy accessor shortcuts
 

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -74,6 +74,7 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
         return self._data.to_mongo(update=update)
 
     def update(self, data, schema=None):
+        self.set_modified()
         return self._data.update(data, schema=schema)
 
     def dump(self, schema=None):

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -75,7 +75,7 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
 
     def update(self, data, schema=None):
         self.set_modified()
-        return self._data.update(data, schema=schema)
+        self._data.update(data, schema=schema)
 
     def dump(self, schema=None):
         return self._data.dump(schema=schema)


### PR DESCRIPTION
This update method is copied from Document, except it calls `self.set_modified` to mark the embedded document as modified.

I also removed the `return` statements in both EmbeddedDocument and Document update methods, as I didn't see the point, but maybe this is wrong.

I also added tests to the new update methods.

Happy to rework this if you have comments.