### PR TITLE
ReferenceField lazy dereference

### DIFF
--- a/umongo/data_objects.py
+++ b/umongo/data_objects.py
@@ -104,13 +104,9 @@ class Reference:
     error_messages = I18nErrorDict(not_found='Reference not found for document {document}.')
 
     def __init__(self, document_cls, pk):
-
-        # Attribute getter/setter/deleter are overridden to provide
-        # direct access to referenced document. We must use __dict__
-        # directly to get around those.
-        self.__dict__['document_cls'] = document_cls
-        self.__dict__['pk'] = pk
-        self.__dict__['_document'] = None
+        self.document_cls = document_cls
+        self.pk = pk
+        self._document = None
 
     def fetch(self, no_data=False):
         """
@@ -135,29 +131,3 @@ class Reference:
         elif isinstance(other, DBRef):
             return self.pk == other.id and self.document_cls.collection.name == other.collection
         return NotImplemented
-
-    def __getitem__(self, name):
-        return self.fetch()[name]
-
-    def __setitem__(self, name, value):
-        self.fetch()[name] = value
-
-    def __delitem__(self, name):
-        del self.fetch()[name]
-
-    def __getattr__(self, name):
-        if name in self.__dict__:
-            return self.__dict__[name]
-        return getattr(self.fetch(), name)
-
-    def __setattr__(self, name, value):
-        if name in self.__dict__:
-            self.__dict__[name] = value
-        else:
-            setattr(self.fetch(), name)
-
-    def __delattr__(self, name):
-        if name in self.__dict__:
-            del self.__dict__[name]
-        else:
-            delattr(self.fetch(), name)

--- a/umongo/data_objects.py
+++ b/umongo/data_objects.py
@@ -83,9 +83,13 @@ class Reference:
     error_messages = I18nErrorDict(not_found='Reference not found for document {document}.')
 
     def __init__(self, document_cls, pk):
-        self.document_cls = document_cls
-        self.pk = pk
-        self._document = None
+
+        # Attribute getter/setter/deleter are overridden to provide
+        # direct access to referenced document. We must use __dict__
+        # directly to get around those.
+        self.__dict__['document_cls'] = document_cls
+        self.__dict__['pk'] = pk
+        self.__dict__['_document'] = None
 
     def fetch(self, no_data=False):
         """
@@ -110,3 +114,29 @@ class Reference:
         elif isinstance(other, DBRef):
             return self.pk == other.id and self.document_cls.collection.name == other.collection
         return NotImplemented
+
+    def __getitem__(self, name):
+        return self.fetch()[name]
+
+    def __setitem__(self, name, value):
+        self.fetch()[name] = value
+
+    def __delitem__(self, name):
+        del self.fetch()[name]
+
+    def __getattr__(self, name):
+        if name in self.__dict__:
+            return self.__dict__[name]
+        return getattr(self.fetch(), name)
+
+    def __setattr__(self, name, value):
+        if name in self.__dict__:
+            self.__dict__[name] = value
+        else:
+            setattr(self.fetch(), name)
+
+    def __delattr__(self, name):
+        if name in self.__dict__:
+            del self.__dict__[name]
+        else:
+            delattr(self.fetch(), name)

--- a/umongo/frameworks/__init__.py
+++ b/umongo/frameworks/__init__.py
@@ -65,6 +65,15 @@ class PyMongoInstance(LazyLoaderInstance):
         super().__init__(*args, **kwargs)
 
 
+class PyMongoInstanceAutoFetch(LazyLoaderInstance):
+    """
+    :class:`umongo.instance.LazyLoaderInstance` implementation for pymongo
+    """
+    def __init__(self, *args, **kwargs):
+        self.BUILDER_CLS = import_module('umongo.frameworks.pymongo').PyMongoBuilderAutoFetch
+        super().__init__(*args, **kwargs)
+
+
 class TxMongoInstance(LazyLoaderInstance):
     """
     :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -277,7 +277,7 @@ class PyMongoReference(Reference):
         return self._document
 
 
-class PyMongoReferenceAutoFetch(Reference):
+class PyMongoReferenceAutoFetch(PyMongoReference):
 
     def __init__(self, document_cls, pk):
         # Attribute getter/setter/deleter are overridden to provide
@@ -286,16 +286,6 @@ class PyMongoReferenceAutoFetch(Reference):
         self.__dict__['document_cls'] = document_cls
         self.__dict__['pk'] = pk
         self.__dict__['_document'] = None
-
-    def fetch(self, no_data=False):
-        if not self._document:
-            if self.pk is None:
-                raise ReferenceError('Cannot retrieve a None Reference')
-            self._document = self.document_cls.find_one(self.pk)
-            if not self._document:
-                raise ValidationError(self.error_messages['not_found'].format(
-                    document=self.document_cls.__name__))
-        return self._document
 
     def __getitem__(self, name):
         return self.fetch()[name]


### PR DESCRIPTION
Here's an attempt to add dereferencing feature to `Reference` (see https://github.com/Scille/umongo/issues/42).

It's pretty hackish... Basically, the idea is that every attribute or item access to `Reference` is redirected to the referenced document, except for attributes in `Reference`'s `__dict__`.

I tried to figure out a better way adding a `__get__` method to `Reference` so that it returns `self.fetch()` when called from another class, but I didn't get it to work.
