### PR TITLE
DataProxy: Empty not_loaded_fields on non-partial loads

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -303,3 +303,16 @@ class TestDataProxy(BaseTest):
         assert d.get('normal') is missing
         assert d.get('loaded') == "foo"
         assert d.get('loaded_but_empty') == missing
+
+        # Partial, then not partial
+        d = DataProxy(MySchema())
+        d.from_mongo({'loaded': "foo", 'loaded_but_empty': missing}, partial=True)
+        assert d.partial is True
+        d.from_mongo({'loaded': "foo", 'loaded_but_empty': missing})
+        assert d.partial is False
+        # Same test with load
+        d = DataProxy(MySchema())
+        d.load({'loaded': "foo", 'loaded_but_empty': missing}, partial=True)
+        assert d.partial is True
+        d.load({'loaded': "foo", 'loaded_but_empty': missing})
+        assert d.partial is False

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -72,6 +72,8 @@ class DataProxy:
             self._data[k] = field.deserialize_from_mongo(v)
         if partial:
             self._collect_partial_fields(data.keys(), as_mongo_fields=True)
+        else:
+            self.not_loaded_fields = ()
         self._add_missing_fields()
         self.clear_modified()
 
@@ -104,6 +106,8 @@ class DataProxy:
         self._data = loaded_data
         if partial:
             self._collect_partial_fields(data)
+        else:
+            self.not_loaded_fields = ()
         self._add_missing_fields()
         self.clear_modified()
 


### PR DESCRIPTION
I may be mistaken, but the way I understand the code, `self.not_loaded_fields` is not reset when loading non-partial, so if a partial load was performed previously, it still has fields missing from this previous load.