### PR TITLE
Add tz_aware parameter to DateTimeField

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -91,14 +91,17 @@ class TestFields(BaseTest):
 
         class MySchema(EmbeddedSchema):
             a = fields.DateTimeField()
+            b = fields.DateTimeField(tz_aware=True)
 
         s = MySchema(strict=True)
-        data, _ = s.load({'a': datetime(2016, 8, 6)})
-        assert data['a'] == datetime(2016, 8, 6)
-        data, _ = s.load({'a': "2016-08-06T00:00:00Z"})
-        assert data['a'] == datetime(2016, 8, 6, tzinfo=tzutc())
-        data, _ = s.load({'a': "2016-08-06T00:00:00"})
-        assert data['a'] == datetime(2016, 8, 6)
+        for date in (
+            datetime(2016, 8, 6),
+            "2016-08-06T00:00:00Z",
+            "2016-08-06T00:00:00",
+        ):
+            data, _ = s.load({'a': date, 'b': date})
+            assert data['a'] == datetime(2016, 8, 6)
+            assert data['b'] == datetime(2016, 8, 6, tzinfo=tzutc())
         with pytest.raises(ValidationError):
             s.load({'a': "dummy"})
 


### PR DESCRIPTION
I tried to implement what you suggested in [#44](https://github.com/Scille/umongo/issues/44#issuecomment-244019780).

For now, I did only `DateTimeField`.

I suppose when merging with https://github.com/Scille/umongo/tree/export_schema we'd move this improved `DateTimeField` to `marshmallow_bonus_fields.py` as a pure Marshmallow field. I could also propose this for integration in Marshmallow.

Should we have both `load_as_tz_aware` and `dump_as_tz_aware`? Currently, I don't mind as I serialize out of the API as TZ aware (Marshmallow's default), but maybe it would be useful to someone else.