### PR TITLE
Fix PyMongo WrappedCursor slicing

### DIFF
--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -159,6 +159,11 @@ class TestPymongo(BaseDBTest):
         cursor_skip = cursor.skip(6)
         assert cursor is cursor_limit is cursor_skip
 
+        # Cursor slicing
+        cursor = Student.find()
+        names = (elem.name for elem in cursor[2:5])
+        assert sorted(names) == ['student-%s' % i for i in range(2, 5)]
+
     def test_classroom(self, classroom_model):
         student = classroom_model.Student(name='Marty McFly', birthday=datetime(1968, 6, 9))
         student.commit()

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -30,12 +30,12 @@ class WrappedCursor(Cursor):
         return setattr(self.raw_cursor, name, value)
 
     def __getitem__(self, index):
-        data = self.raw_cursor[index]
-        if isinstance(data, Cursor):
+        if isinstance(index, slice):
+            elems = self.raw_cursor[index]
             return (self.document_cls.build_from_mongo(elem, use_cls=True)
-                    for elem in data)
-        else:
-            return self.document_cls.build_from_mongo(data, use_cls=True)
+                    for elem in elems)
+        elem = self.raw_cursor[index]
+        return self.document_cls.build_from_mongo(elem, use_cls=True)
 
     def __next__(self):
         elem = next(self.raw_cursor)

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -30,8 +30,12 @@ class WrappedCursor(Cursor):
         return setattr(self.raw_cursor, name, value)
 
     def __getitem__(self, index):
-        elem = self.raw_cursor[index]
-        return self.document_cls.build_from_mongo(elem, use_cls=True)
+        data = self.raw_cursor[index]
+        if isinstance(data, Cursor):
+            return (self.document_cls.build_from_mongo(elem, use_cls=True)
+                    for elem in data)
+        else:
+            return self.document_cls.build_from_mongo(data, use_cls=True)
 
     def __next__(self):
         elem = next(self.raw_cursor)


### PR DESCRIPTION
This allows slicing umongo's PyMongo WrappedCursor like you would slice a PyMongo Cursor.

```py
    cursor = Student.find()
    for elem in cursor[2:5]:
        ...
```