### PR TITLE
Fix missing "assert" statements in tests

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -126,7 +126,7 @@ class TestFields(BaseTest):
         assert d.to_mongo(update=True) is None
 
         d2 = MyDataProxy({'dict': {}})
-        d2.to_mongo() == {'dict': {}}
+        assert d2.to_mongo() == {'dict': {}}
 
         d3 = MyDataProxy()
         d3.from_mongo({})
@@ -392,11 +392,11 @@ class TestFields(BaseTest):
         assert d.get('objid') == ObjectId("5672d47b1d41c88dcd37ef05")
 
         d.set('objid', ObjectId("5672d5e71d41c88f914b77c4"))
-        d.to_mongo(update=True) == {
+        assert d.to_mongo(update=True) == {
             '$set': {'in_mongo_objid': ObjectId("5672d5e71d41c88f914b77c4")}}
 
         d.set('objid', ObjectId("5672d5e71d41c88f914b77c4"))
-        d.to_mongo(update=True) == {
+        assert d.to_mongo(update=True) == {
             '$set': {'in_mongo_objid': ObjectId("5672d5e71d41c88f914b77c4")}}
 
         d.set('objid', "5672d5e71d41c88f914b77c4")
@@ -443,7 +443,7 @@ class TestFields(BaseTest):
         d.load({'ref': ObjectId("5672d47b1d41c88dcd37ef05")})
         d.load({'ref': "5672d47b1d41c88dcd37ef05"})
         assert d.dump() == {'ref': "5672d47b1d41c88dcd37ef05"}
-        d.get('ref').document_cls == MyReferencedDoc
+        assert d.get('ref').document_cls == MyReferencedDoc
         d.set('ref', to_refer_doc)
         assert d.to_mongo(update=True) == {'$set': {'in_mongo_ref': to_refer_doc.pk}}
         assert d.get('ref') == ref
@@ -509,7 +509,7 @@ class TestFields(BaseTest):
         d = MyDataProxy()
         d.load({'gref': {'id': ObjectId("5672d47b1d41c88dcd37ef05"), 'cls': ToRef2.__name__}})
         assert d.dump() == {'gref': {'id': "5672d47b1d41c88dcd37ef05", 'cls': 'ToRef2'}}
-        d.get('gref').document_cls == ToRef2
+        assert d.get('gref').document_cls == ToRef2
         d.set('gref', doc1)
         assert d.to_mongo(update=True) == {
             '$set': {'in_mongo_gref': {'_id': doc1.pk, '_cls': 'ToRef1'}}}

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -1,9 +1,9 @@
 import pytest
 from datetime import datetime
-from bson import ObjectId, DBRef
+from bson import ObjectId
 import marshmallow
 
-from umongo import Document, EmbeddedDocument, Schema, fields, exceptions, set_gettext, validate
+from umongo import Document, EmbeddedDocument, fields, set_gettext, validate
 from umongo import marshmallow_bonus as ma_bonus_fields
 from umongo.abstract import BaseField, BaseSchema
 from umongo.marshmallow_bonus import (
@@ -267,7 +267,7 @@ class TestMarshmallow(BaseTest):
 
             @property
             def prop(self):
-                return "I'm a proerty !"
+                return "I'm a property !"
 
         class VanillaSchema(marshmallow.Schema):
             a = marshmallow.fields.Int()
@@ -277,15 +277,15 @@ class TestMarshmallow(BaseTest):
 
         data, errors = VanillaSchema().dump(Doc())
         assert not errors
-        data == {'a': None}
+        assert data == {'a': None}
 
         data, errors = CustomGetAttributeSchema().dump(Doc())
         assert not errors
-        data == {}
+        assert data == {}
 
         data, errors = CustomGetAttributeSchema().dump(Doc(a=1))
         assert not errors
-        data == {'a': 1}
+        assert data == {'a': 1}
 
         class MySchemaFromUmongo(SchemaFromUmongo):
             a = marshmallow.fields.Int()
@@ -293,7 +293,7 @@ class TestMarshmallow(BaseTest):
 
         data, errors = MySchemaFromUmongo().dump(Doc())
         assert not errors
-        data == {'prop': "I'm a property !"}
+        assert data == {'prop': "I'm a property !"}
 
         _, errors = MySchemaFromUmongo().load({'a': 1, 'dummy': 2})
         assert errors == {'_schema': ['Unknown field name dummy.']}


### PR DESCRIPTION
Looks like some `assert` statements are missing.

This commit also fixes a typo and removes unused imports.

Note that this fix spots an issue in `DictField` (or in the test).