### PR TITLE
 Add `conditions` to delete method

### DIFF
--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -136,7 +136,12 @@ class TestMotorAsyncio(BaseDBTest):
             yield from john.commit()
             assert john.is_created
             assert (yield from Student.find().count()) == 1
+            # Test conditional delete
+            with pytest.raises(exceptions.DeleteError):
+                yield from john.remove(conditions={'name': 'Bad Name'})
+            yield from john.remove(conditions={'name': 'John Doe'})
             # Finally try to remove a doc no longer in database
+            yield from john.commit()
             yield from (yield from Student.find_one(john.id)).remove()
             with pytest.raises(exceptions.DeleteError):
                 yield from john.remove()

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -116,7 +116,12 @@ class TestPymongo(BaseDBTest):
         john.commit()
         assert john.is_created
         assert Student.collection.find().count() == 1
+        # Test conditional delete
+        with pytest.raises(exceptions.DeleteError):
+            john.delete(conditions={'name': 'Bad Name'})
+        john.delete(conditions={'name': 'John Doe'})
         # Finally try to delete a doc no longer in database
+        john.commit()
         Student.find_one(john.id).delete()
         with pytest.raises(exceptions.DeleteError):
             john.delete()

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -144,7 +144,12 @@ class TestTxMongo(BaseDBTest):
         assert john.is_created
         students = yield Student.find()
         assert len(students) == 1
+        # Test conditional delete
+        with pytest.raises(exceptions.DeleteError):
+            yield john.delete(conditions={'name': 'Bad Name'})
+        yield john.delete(conditions={'name': 'John Doe'})
         # Finally try to delete a doc no longer in database
+        yield john.commit()
         yield students[0].delete()
         with pytest.raises(exceptions.DeleteError):
             yield john.delete()

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -284,6 +284,8 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
     def pre_delete(self):
         """
         Overload this method to get a callback before document deletion.
+        :return: Additional filters dict that will be used for the query to
+            select the document to update.
 
         .. note:: If you use an async driver, this callback can return a defer/future.
         """

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -132,10 +132,14 @@ class PyMongoDocument(DocumentImplementation):
         self._data.clear_modified()
         return ret
 
-    def delete(self):
+    def delete(self, conditions=None):
         """
         Remove the document from database.
 
+        :param conditions: Only perform delete if matching record in db
+            satisfies condition(s) (e.g. version number).
+            Raises :class:`umongo.exceptions.DeleteError` if the
+            conditions are not satisfied.
         Raises :class:`umongo.exceptions.NotCreatedError` if the document
         is not created (i.e. ``doc.is_created`` is False)
         Raises :class:`umongo.exceptions.DeleteError` if the document
@@ -146,7 +150,9 @@ class PyMongoDocument(DocumentImplementation):
         if not self.is_created:
             raise NotCreatedError("Document doesn't exists in database")
         self.pre_delete()
-        ret = self.collection.delete_one({'_id': self.pk})
+        query = conditions or {}
+        query['_id'] = self.pk
+        ret = self.collection.delete_one(query)
         if ret.deleted_count != 1:
             raise DeleteError(ret)
         self.is_created = False

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -149,9 +149,12 @@ class PyMongoDocument(DocumentImplementation):
         """
         if not self.is_created:
             raise NotCreatedError("Document doesn't exists in database")
-        self.pre_delete()
         query = conditions or {}
         query['_id'] = self.pk
+        # pre_delete can provide additional query filter
+        additional_filter = self.pre_delete()
+        if additional_filter:
+            query.update(map_query(additional_filter, self.schema.fields))
         ret = self.collection.delete_one(query)
         if ret.deleted_count != 1:
             raise DeleteError(ret)

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -124,7 +124,7 @@ class TxMongoDocument(DocumentImplementation):
         additional_filter = yield maybeDeferred(self.pre_delete)
         if additional_filter:
             query.update(map_query(additional_filter, self.schema.fields))
-        ret = yield self.collection.delete_one({'_id': self.pk})
+        ret = yield self.collection.delete_one(query)
         if ret.deleted_count != 1:
             raise DeleteError(ret)
         self.is_created = False


### PR DESCRIPTION
Trying to address https://github.com/Scille/umongo/issues/35.

Incidentally, in motor_asyncio, `pre_delete` is now executed only if doc is created, like on the other frameworks.

Also added possibility for `pre_delete` to add additional query filters, like `pre_update`.