### PR TITLE
Fix update not loaded fields

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -347,3 +347,14 @@ class TestDataProxy(BaseTest):
         assert d.partial is True
         d.load({'loaded': "foo", 'loaded_but_empty': missing})
         assert d.partial is False
+
+        # Load partial, then update
+        d = MyDataProxy()
+        d.load({'loaded': "foo", 'loaded_but_empty': missing}, partial=True)
+        assert d.partial is True
+        assert len(d.not_loaded_fields) == 3
+        d.update({'normal': "bar"})
+        assert d.partial is True
+        assert len(d.not_loaded_fields) == 2
+        d.update({'with_default': "monthy", 'with_missing': 'python'})
+        assert d.partial is False

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -87,6 +87,8 @@ class BaseDataProxy:
         if err:
             raise ValidationError(err)
         self._data.update(loaded_data)
+        self.not_loaded_fields = tuple(
+            set(self.not_loaded_fields) - set(self._fields[k] for k in data))
         for key in loaded_data:
             self._mark_as_modified(key)
 


### PR DESCRIPTION
See https://github.com/Scille/umongo/pull/45#issuecomment-244017493:

> Likewise, maybe we should do something in DataProxy.update() to update not_loaded_fields. If new fields have been loaded, they should be removed from not_loaded_fields, right?