### PR TITLE
Fix dataproxy update not_loaded_fields

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -273,7 +273,7 @@ class TestDataProxy(BaseTest):
         class MySchema(EmbeddedSchema):
             with_default = fields.StrField(default='default_value')
             with_missing = fields.StrField(missing='missing_value')
-            normal = fields.StrField()
+            normal = fields.StrField(attribute='in_mongo_normal')
             loaded = fields.StrField()
             loaded_but_empty = fields.StrField()
 

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -88,7 +88,7 @@ class BaseDataProxy:
             raise ValidationError(err)
         self._data.update(loaded_data)
         if self.not_loaded_fields:
-            for k in loaded_data:
+            for k in data:
                 self.not_loaded_fields.discard(self._fields[k])
         for key in loaded_data:
             self._mark_as_modified(key)


### PR DESCRIPTION
See comment: https://github.com/Scille/umongo/commit/1dd4076998c4171e2482bd4609933c761311e2e2#commitcomment-19075700

> I think it should be
> 
>     for k in data:
> 
> otherwise it chokes on fields with attribute.
