### PR TITLE
Serialization issue with DictField

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,3 +1,4 @@
+import json
 from bson import ObjectId, DBRef
 import pytest
 from datetime import datetime
@@ -176,6 +177,17 @@ class TestFields(BaseTest):
         d3.get('dict').set_modified()
         assert d3.to_mongo(update=True) == {'$set': {'in_mongo_dict': {'field': 'value'}}}
         assert d3.to_mongo() == {'in_mongo_dict': {'field': 'value'}}
+
+        # Test dict serialization
+        @self.instance.register
+        class AdvancedUser(Document):
+            test = fields.DictField()
+
+        ma_schema_cls = AdvancedUser.schema.as_marshmallow_schema()
+        schema = ma_schema_cls()
+        test = AdvancedUser(test={'lol': 2, 'rofl': 1})
+        s = schema.dump(test)
+        json.dumps(s)
 
     def test_embedded_document(self):
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -79,6 +79,20 @@ class DictField(BaseField, ma_fields.Dict):
         self.attribute or keys[0] + '.' + '.'.join(keys[1:])
         return {self.attribute or key: query}
 
+    def as_marshmallow_field(self, params=None, mongo_world=False):
+        kwargs = self._extract_marshmallow_field_params(mongo_world)
+        if params:
+            kwargs.update(params)
+        m_field = ma_fields.Dict(**kwargs)
+
+        # Monkey patch Dict to return a dict rather than a UserDict
+        def _serialize(value, attr, obj):
+            if isinstance(value, Dict):
+                return value.data
+        m_field._serialize = _serialize
+
+        return m_field
+
 
 class ListField(BaseField, ma_fields.List):
 


### PR DESCRIPTION
I have an issue with the introduction of `UserDict`. See this PR for test case and workaround.

Basically, when I export a schema with a `DictField` as a Marshmallow `Schema`, the `Dict` field serializes as a `UserField`, because `_serialize` in `Dict` is noop. Unfortunately, `UserField` does not really behave like a dict. `isinstance(UserDict(), dict)` returns `False`. Besides, `json.dumps()` will throw a `TypeError` on a `UserDict`.

```python
    import json
    from collections import UserDict
    json.dumps(UserDict(a=42))
    Traceback (most recent call last):
      File "<stdin>", line 1, in <module>
      File "/usr/lib/python3.4/json/__init__.py", line 230, in dumps
        return _default_encoder.encode(obj)
      File "/usr/lib/python3.4/json/encoder.py", line 192, in encode
        chunks = self.iterencode(o, _one_shot=True)
      File "/usr/lib/python3.4/json/encoder.py", line 250, in iterencode
        return _iterencode(o, 0)
      File "/usr/lib/python3.4/json/encoder.py", line 173, in default
        raise TypeError(repr(o) + " is not JSON serializable")
    TypeError: {'a': 42} is not JSON serializable
```

I had a hard time figuring this out, and I'm not sure where it should be addressed.

A real `dict` can be accessed:

```py
    json.dumps(UserDict(a=42).data)
    '{"a": 42}'
    json.dumps(dict(UserDict(a=42)))
    '{"a": 42}'
```

and this is how I worked this around (see PR).

Feedback welcome.

Enjoy PyCon!