### PR TITLE
Make inheritance _cls field load_only

### DIFF
--- a/umongo/schema.py
+++ b/umongo/schema.py
@@ -30,7 +30,7 @@ def on_need_add_id_field(bases, fields):
 
 def add_child_field(name, fields):
     from .fields import StrField
-    fields['cls'] = StrField(attribute='_cls', missing=name, dump_only=True)
+    fields['cls'] = StrField(attribute='_cls', missing=name, dump_only=True, load_only=True)
 
 
 class Schema(BaseSchema):


### PR DESCRIPTION
Shouldn't _cls field be load-only?

AFAIU, this is internal stuff. It does not have to be exposed through the API when serializing the data.