### PR TITLE
DataProxy.set(): don't call validation if allow_none = True and value is None

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -113,6 +113,10 @@ class TestDataProxy(BaseTest):
         class MySchema(EmbeddedSchema):
             a = fields.IntField()
             b = fields.IntField(attribute='in_mongo_b')
+            c = fields.IntField(
+                allow_none=True,
+                validate=validate.Range(min=1, max=5)
+            )
 
         MyDataProxy = data_proxy_factory('My', MySchema())
         d = MyDataProxy()
@@ -128,6 +132,12 @@ class TestDataProxy(BaseTest):
 
         with pytest.raises(KeyError):
             d.set('in_mongo_b', 2)
+
+        d.from_mongo({})
+        d.set('c', None)
+        assert d.to_mongo() == {'c': None}
+        with pytest.raises(ValidationError):
+            d.set('c', 69)
 
     def test_del(self):
 

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -145,7 +145,7 @@ class BaseDataProxy:
     def set(self, name, value, to_raise=KeyError):
         name, field = self._get_field(name, to_raise)
         value = field._deserialize(value, name, None)
-        if getattr(field, 'allow_none', False) is False or value is not None:
+        if value is not None or not getattr(field, 'allow_none', False):
             field._validate(value)
         self._data[name] = value
         self._mark_as_modified(name)

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -145,7 +145,8 @@ class BaseDataProxy:
     def set(self, name, value, to_raise=KeyError):
         name, field = self._get_field(name, to_raise)
         value = field._deserialize(value, name, None)
-        field._validate(value)
+        if getattr(field, 'allow_none', False) is False or value is not None:
+            field._validate(value)
         self._data[name] = value
         self._mark_as_modified(name)
 


### PR DESCRIPTION
Current implementation of `DataProxy.set()` does not allow setting `None` in a field with `allow_none = True` and validators defined, because it calls validation on the value even if it is `None`.

In Marshmallow, the validators are not called in this case (see https://github.com/marshmallow-code/marshmallow/blob/e6ddef938b3b274a4965cad344c3864e643e6baa/marshmallow/fields.py#L254).

My explanation sucks, but hopefully, the tests will speak for themselves...
