### PR TITLE
Failing tests for EmbeddedDocument issues

### DIFF
--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -91,6 +91,9 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
             use it determine the EmbeddedDocument class to instanciate
         """
         # If a _cls is specified, we have to use this document class
+        print('build_from_mongo')
+        print(type(data))
+        print(data)
         if use_cls and '_cls' in data:
             cls = cls.opts.instance.retrieve_embedded_document(data['_cls'])
         doc = cls()
@@ -122,6 +125,7 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
     # Data-proxy accessor shortcuts
 
     def __getitem__(self, name):
+        print("name", name)
         value = self._data.get(name)
         return value if value is not missing else None
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -410,6 +410,8 @@ class EmbeddedField(BaseField, ma_fields.Nested):
         return value.dump()
 
     def _deserialize(self, value, attr, data):
+        print("_deserialize")
+        print(value)
         embedded_document_cls = self.embedded_document_cls
         if isinstance(value, embedded_document_cls):
             return value


### PR DESCRIPTION
Hopefully, this will help you get an idea of the issues I'm facing.

I purposely left the debug `print` statements.

You'll see that in `EmbeddedField._deserialize`, the deserialization is done recursively and in the end `_deserialize_from_mongo` is called with an object that is not a `dict` but an `Implementation` class.

Then in `EmbeddedDocument.build_from_mongo`, the `'_cls in data'` test raises an exception because `key in some_embedded_doc_instance` is invalid.

I don't claim I have the whole picture clear, but I still think the root cause is calling "from_mongo" stuff to do OO deserialization.

I hope the testcase helps, but frankly, I'd start by wondering about the "from_mongo" stuff in `_deserialize` as the whole thing may unravel from there.

My hacky-fix branch in https://github.com/Scille/umongo/pull/56 passes the tests. The implementation may have issues as well, so it is not meant to be integrated as is, but it may shed light on my explanation and point where the issue can be.

Please ask for clarification is this is still too blurry.