### PR TITLE
Let as_marshmallow_field pass metadata

### DIFF
--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -78,8 +78,16 @@ class TestMarshmallow(BaseTest):
     def test_keep_attributes(self):
         @self.instance.register
         class Vehicle(Document):
-            pass
-        # TODO
+            category = fields.StrField(required=True)
+            nb_wheels = fields.IntField(missing=4)
+
+        ma_schema_cls = Vehicle.schema.as_marshmallow_schema()
+        schema = ma_schema_cls()
+
+        ret = schema.load({})
+        assert ret.errors == {'category': ['Missing data for required field.']}
+        ret = schema.load({'category': 'Car'})
+        assert ret.data == {'category': 'Car', 'nb_wheels': 4}
 
     def test_keep_validators(self):
         @self.instance.register

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -78,6 +78,7 @@ class TestMarshmallow(BaseTest):
     def test_keep_attributes(self):
         @self.instance.register
         class Vehicle(Document):
+            brand = fields.StrField(description='Manufacturer name')
             category = fields.StrField(required=True)
             nb_wheels = fields.IntField(missing=4)
 
@@ -88,6 +89,8 @@ class TestMarshmallow(BaseTest):
         assert ret.errors == {'category': ['Missing data for required field.']}
         ret = schema.load({'category': 'Car'})
         assert ret.data == {'category': 'Car', 'nb_wheels': 4}
+
+        assert schema.fields['brand'].metadata['description'] == 'Manufacturer name'
 
     def test_keep_validators(self):
         @self.instance.register

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -179,6 +179,7 @@ class BaseField(ma_fields.Field):
                                 'dump_only', 'missing', 'error_messages')}
         if mongo_world and self.attribute:
             params['attribute'] = self.attribute
+        params.update(self.metadata)
         return params
 
     def as_marshmallow_field(self, params=None, mongo_world=False):


### PR DESCRIPTION
Sometimes, it is useful to pass a field arbitrary names attributes that are used in the application. Marshmallow supports this and stores those attributes in `Field.metadata`.

For instance, when using Marshmallow + apispec, [API specific parameters](https://github.com/marshmallow-code/apispec/blob/dev/apispec/ext/marshmallow/swagger.py#L165) can be passed to the `Schema` when declaring the model.

It would be nice to be able to declare those attributes in each uMongo `Field`. It looks as easy as just passing the `metadata` as kwargs when creating the Marshmallow field.

I don't see any drawback to this, except it may pass metadata that was there for uMongo purposes and wasn't meant to trickle down to Marshmallow, but I think Marshmallow will just silently ignore it, this shouldn't be a blocker for that feature.

Here's an implementation proposal. The patch is dead simple.

I added a few tests in test_keep_attributes which was labeled as `TODO`. I hope this is what you had in mind for this function. Otherwise, I can rework this.