### PR TITLE
Fix allow_none fields [de|]serialization

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,7 @@ History
 
 dev
 ---
+* Fix fields serialization/deserialization when allow_none is True (see #69)
 * Fix ReferenceFild assignment from another ReferenceField (see #110)
 * Fix deletion of field proxied by a property (see #109)
 * Fix StrictDateTime bonus field: _deserialize does not accept datetime.datetime

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -28,7 +28,6 @@ class TestEmbeddedDocument(BaseTest):
 
         assert document is not None
 
-
     def test_embedded_document(self):
         @self.instance.register
         class MyEmbeddedDocument(EmbeddedDocument):
@@ -41,7 +40,8 @@ class TestEmbeddedDocument(BaseTest):
 
         @self.instance.register
         class MyDoc(Document):
-            embedded = fields.EmbeddedField(MyEmbeddedDocument, attribute='in_mongo_embedded')
+            embedded = fields.EmbeddedField(MyEmbeddedDocument,
+                attribute='in_mongo_embedded', allow_none=True)
 
         MySchema = MyDoc.Schema
 
@@ -125,6 +125,12 @@ class TestEmbeddedDocument(BaseTest):
             embedded_doc['dummy'] = None
         with pytest.raises(KeyError):
             del embedded_doc['dummy']
+
+        # Test allow_none
+        d3 = MyDataProxy({'embedded': None})
+        assert d3.to_mongo() == {'in_mongo_embedded': None}
+        d3.from_mongo({'in_mongo_embedded': None})
+        assert d3.get('embedded') is None
 
     def test_bad_embedded_document(self):
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -216,7 +216,7 @@ class TestFields(BaseTest):
     def test_dict(self):
 
         class MySchema(Schema):
-            dict = fields.DictField(attribute='in_mongo_dict')
+            dict = fields.DictField(attribute='in_mongo_dict', allow_none=True)
 
         MyDataProxy = data_proxy_factory('My', MySchema())
         d = MyDataProxy()
@@ -255,10 +255,15 @@ class TestFields(BaseTest):
         assert d3.to_mongo(update=True) == {'$set': {'in_mongo_dict': {'field': 'value'}}}
         assert d3.to_mongo() == {'in_mongo_dict': {'field': 'value'}}
 
+        d4 = MyDataProxy({'dict': None})
+        assert d4.to_mongo() == {'in_mongo_dict': None}
+        d4.from_mongo({'in_mongo_dict': None})
+        assert d4.get('dict') is None
+
     def test_list(self):
 
         class MySchema(Schema):
-            list = fields.ListField(fields.IntField(), attribute='in_mongo_list')
+            list = fields.ListField(fields.IntField(), attribute='in_mongo_list', allow_none=True)
 
         MyDataProxy = data_proxy_factory('My', MySchema())
         d = MyDataProxy()
@@ -318,6 +323,11 @@ class TestFields(BaseTest):
         # Test repr readability
         repr_d = repr(d.get('list'))
         assert repr_d == "<object umongo.data_objects.List([2, 3, 4, 5])>"
+
+        d3 = MyDataProxy({'list': None})
+        assert d3.to_mongo() == {'in_mongo_list': None}
+        d3.from_mongo({'in_mongo_list': None})
+        assert d3.get('list') is None
 
     def test_complexe_list(self):
 
@@ -436,7 +446,7 @@ class TestFields(BaseTest):
 
         @self.instance.register
         class MyDoc(Document):
-            ref = fields.ReferenceField(MyReferencedDoc, attribute='in_mongo_ref')
+            ref = fields.ReferenceField(MyReferencedDoc, attribute='in_mongo_ref', allow_none=True)
 
         MySchema = MyDoc.Schema
 
@@ -463,11 +473,16 @@ class TestFields(BaseTest):
         with pytest.raises(ValidationError):
             d.set('ref', bad_ref)
 
+        d2 = MyDataProxy({'ref': None})
+        assert d2.to_mongo() == {'in_mongo_ref': None}
+        d2.from_mongo({'in_mongo_ref': None})
+        assert d2.get('ref') is None
+
         # Test from_mongo behavior with already deserialized data
-        d2 = MyDataProxy()
-        d2.from_mongo({
+        d3 = MyDataProxy()
+        d3.from_mongo({
             'in_mongo_ref': Reference(MyReferencedDoc, ObjectId("5672d47b1d41c88dcd37ef05"))})
-        assert not isinstance(d2._data['in_mongo_ref'].pk, Reference)
+        assert not isinstance(d3._data['in_mongo_ref'].pk, Reference)
 
     def test_reference_lazy(self):
 
@@ -509,7 +524,7 @@ class TestFields(BaseTest):
 
         @self.instance.register
         class MyDoc(Document):
-            gref = fields.GenericReferenceField(attribute='in_mongo_gref')
+            gref = fields.GenericReferenceField(attribute='in_mongo_gref', allow_none=True)
 
         MySchema = MyDoc.Schema
 
@@ -545,8 +560,13 @@ class TestFields(BaseTest):
             with pytest.raises(ValidationError):
                 d.set('gref', v)
 
+        d2 = MyDataProxy({'gref': None})
+        assert d2.to_mongo() == {'in_mongo_gref': None}
+        d2.from_mongo({'in_mongo_gref': None})
+        assert d2.get('gref') is None
+
         # Test from_mongo behavior with already deserialized data
-        d2 = MyDataProxy()
-        d2.from_mongo({
+        d3 = MyDataProxy()
+        d3.from_mongo({
             'in_mongo_gref': Reference(ToRef1, ObjectId("5672d47b1d41c88dcd37ef05"))})
-        assert not isinstance(d2._data['in_mongo_gref'].pk, Reference)
+        assert not isinstance(d3._data['in_mongo_gref'].pk, Reference)

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -127,6 +127,8 @@ class BaseField(ma_fields.Field):
         return super().deserialize(value, attr=attr, data=data)
 
     def serialize_to_mongo(self, obj):
+        if obj is None and getattr(self, 'allow_none', False) is True:
+            return None
         if obj is missing:
             return missing
         return self._serialize_to_mongo(obj)

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -135,6 +135,8 @@ class BaseField(ma_fields.Field):
     #     return self._serialize_to_mongo(attr, obj=obj, update=update)
 
     def deserialize_from_mongo(self, value):
+        if value is None and getattr(self, 'allow_none', False) is True:
+            return None
         return self._deserialize_from_mongo(value)
 
     def _serialize_to_mongo(self, obj):


### PR DESCRIPTION
I'm afraid there's an issue with `allow_none` fields.

For both serialization and deserialization to/from Mongo, if the value is None, None should be returned and all `_(de)serialize_from_mongo` overridden methods should be skipped, as they don't deal with the `allow_none` case and either break (e.g. StrictDateTime) or return a nullish object (empty list, empty dict).

See attached fix proposal.

I didn't code any test as I'm in a bit of a rush and I'd rather have your feedback first.