### PR TITLE
Don't fail if missing embedded doc with required fields

### DIFF
--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -309,8 +309,7 @@ class TestMotorAsyncio(BaseDBTest):
 
             MySchema = MyDoc.Schema
             MyDoc(embedded={}, embedded_list=[{}])  # Required fields are check on commit
-            with pytest.raises(exceptions.ValidationError):
-                yield from MyDoc().commit()
+            yield from MyDoc().commit()  # Don't check required fields in missing embedded
             with pytest.raises(exceptions.ValidationError):
                 yield from MyDoc(embedded={'optional_field': 1}).commit()
             with pytest.raises(exceptions.ValidationError):

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -225,8 +225,7 @@ class TestPymongo(BaseDBTest):
 
         MySchema = MyDoc.Schema
         MyDoc(embedded={}, embedded_list=[{}])  # Required fields are check on commit
-        with pytest.raises(exceptions.ValidationError):
-            MyDoc().commit()
+        MyDoc().commit()  # Don't check required fields in missing embedded
         with pytest.raises(exceptions.ValidationError):
             MyDoc(embedded={'optional_field': 1}).commit()
         with pytest.raises(exceptions.ValidationError):

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -260,8 +260,7 @@ class TestTxMongo(BaseDBTest):
 
         MySchema = MyDoc.Schema
         MyDoc(embedded={}, embedded_list=[{}])  # Required fields are check on commit
-        with pytest.raises(exceptions.ValidationError):
-            yield MyDoc().commit()
+        yield MyDoc().commit()  # Don't check required fields in missing embedded
         with pytest.raises(exceptions.ValidationError):
             yield MyDoc(embedded={'optional_field': 1}).commit()
         with pytest.raises(exceptions.ValidationError):

--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -402,7 +402,11 @@ class TestDataProxy(BaseTest):
             d.required_validate()
         assert exc.value.messages == {'required': ['Missing data for required field.']}
 
+        # Missing embedded is valid even though some fields are required in the embedded document
         d.load({'required': 42})
+        d.required_validate()
+        # Required fields in the embedded document are only checked if the document is not missing
+        d.load({'embedded': {}, 'required': 42})
         with pytest.raises(ValidationError) as exc:
             d.required_validate()
         assert exc.value.messages == {'embedded': {'required': ['Missing data for required field.']}}

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -118,7 +118,7 @@ class BaseField(ma_fields.Field):
         return super().serialize(attr, obj, accessor=accessor)
 
     def _validate_missing(self, value):
-        # Overwirte marshmallow.Field._validate_missing given it also checks
+        # Overwrite marshmallow.Field._validate_missing given it also checks
         # for missing required fields (this is done at commit time in umongo
         # using `DataProxy.required_validate`).
         if value is None and getattr(self, 'allow_none', False) is False:

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -493,8 +493,5 @@ class EmbeddedField(BaseField, ma_fields.Nested):
         return ma_fields.Nested(nested_ma_schema, **kwargs)
 
     def _required_validate(self, value):
-        if value is missing:
-            # Validate against an empty struct to enforce required fields check
-            self._embedded_document_cls.DataProxy(data={}).required_validate()
-        else:
+        if value is not missing:
             value.required_validate()


### PR DESCRIPTION
Please tell me what you think about this.

Currently, required fields validation fails if an embedded document with required fields is missing, even if the embedded document itself is not required.

I think this should fail only if the embedded document itself is required.

Consider this model:

```
User
  - name (string, required)

Team
  - manager (embedded user, not required)
```

manager field in Team is not required. If a manager is provided, it should have a name (required field), but if no manager is provided, I don't think validation should fail. No manager, no problem!

It should fail only 

- if manager is required 

- or if manager is provided without name, whether or not it is required.