### PR TITLE
Fix required check on update

### DIFF
--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -255,7 +255,6 @@ class TestMotorAsyncio(BaseDBTest):
 
         loop.run_until_complete(do_test())
 
-
     def test_validation_on_commit(self, loop, instance):
 
         @asyncio.coroutine
@@ -275,6 +274,13 @@ class TestMotorAsyncio(BaseDBTest):
             with pytest.raises(exceptions.ValidationError) as exc:
                 yield from Dummy(required_name='required', always_io_fail=42).commit()
             assert exc.value.messages == {'always_io_fail': ['Ho boys !']}
+
+            dummy = Dummy(required_name='required')
+            yield from dummy.commit()
+            del dummy.required_name
+            with pytest.raises(exceptions.ValidationError) as exc:
+                yield from dummy.commit()
+            assert exc.value.messages == {'required_name': ['Missing data for required field.']}
 
         loop.run_until_complete(do_test())
 

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -192,15 +192,9 @@ class TestPymongo(BaseDBTest):
             raise exceptions.ValidationError('Ho boys !')
 
         @instance.register
-        class EmbeddedDummy(EmbeddedDocument):
-            required_field = fields.StrField(required=True)
-
-        @instance.register
         class Dummy(Document):
             required_name = fields.StrField(required=True)
             always_io_fail = fields.IntField(io_validate=io_validate)
-            embedded_list = fields.ListField(fields.EmbeddedField(EmbeddedDummy))
-            embedded = fields.EmbeddedField(EmbeddedDummy)
 
         with pytest.raises(exceptions.ValidationError) as exc:
             Dummy().commit()
@@ -209,38 +203,12 @@ class TestPymongo(BaseDBTest):
             Dummy(required_name='required', always_io_fail=42).commit()
         assert exc.value.messages == {'always_io_fail': ['Ho boys !']}
 
-        with pytest.raises(exceptions.ValidationError) as exc:
-            Dummy(required_name='required', embedded=EmbeddedDummy()).commit()
-        assert exc.value.messages == {'embedded': {'required_field':
-                ['Missing data for required field.']}}
-
         dummy = Dummy(required_name='required')
         dummy.commit()
         del dummy.required_name
         with pytest.raises(exceptions.ValidationError) as exc:
             dummy.commit()
         assert exc.value.messages == {'required_name': ['Missing data for required field.']}
-
-        dummy = Dummy(required_name='required')
-        dummy.commit()
-        dummy.embedded = EmbeddedDummy()
-        with pytest.raises(exceptions.ValidationError) as exc:
-            dummy.commit()
-        assert exc.value.messages == {'embedded': {'required_field':
-                ['Missing data for required field.']}}
-
-        with pytest.raises(exceptions.ValidationError) as exc:
-            Dummy(required_name='required', embedded_list=[EmbeddedDummy()]).commit()
-        assert exc.value.messages == {'embedded_list': {0: {'required_field':
-                ['Missing data for required field.']}}}
-
-        dummy = Dummy(required_name='required')
-        dummy.commit()
-        dummy.embedded_list.append(EmbeddedDummy())
-        with pytest.raises(exceptions.ValidationError) as exc:
-            dummy.commit()
-        assert exc.value.messages == {'embedded_list': {0: {'required_field':
-                ['Missing data for required field.']}}}
 
     def test_reference(self, classroom_model):
         teacher = classroom_model.Teacher(name='M. Strickland')

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -236,6 +236,13 @@ class TestTxMongo(BaseDBTest):
             yield Dummy(required_name='required', always_io_fail=42).commit()
         assert exc.value.messages == {'always_io_fail': ['Ho boys !']}
 
+        dummy = Dummy(required_name='required')
+        yield dummy.commit()
+        del dummy.required_name
+        with pytest.raises(exceptions.ValidationError) as exc:
+            yield dummy.commit()
+        assert exc.value.messages == {'required_name': ['Missing data for required field.']}
+
     @pytest_inlineCallbacks
     def test_reference(self, classroom_model):
         teacher = classroom_model.Teacher(name='M. Strickland')

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -130,6 +130,7 @@ class MotorAsyncIODocument(DocumentImplementation):
                     additional_filter = yield from self.__coroutined_pre_update()
                     if additional_filter:
                         query.update(map_query(additional_filter, self.schema.fields))
+                    self.required_validate()
                     yield from self.io_validate(validate_all=io_validate_all)
                     payload = self._data.to_mongo(update=True)
                     ret = yield from self.collection.update(query, payload)

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -92,6 +92,7 @@ class PyMongoDocument(DocumentImplementation):
                     additional_filter = self.pre_update()
                     if additional_filter:
                         query.update(map_query(additional_filter, self.schema.fields))
+                    self.required_validate()
                     self.io_validate(validate_all=io_validate_all)
                     payload = self._data.to_mongo(update=True)
                     ret = self.collection.update_one(query, payload)

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -62,6 +62,7 @@ class TxMongoDocument(DocumentImplementation):
                     additional_filter = yield maybeDeferred(self.pre_update)
                     if additional_filter:
                         query.update(map_query(additional_filter, self.schema.fields))
+                    self.required_validate()
                     yield self.io_validate(validate_all=io_validate_all)
                     payload = self._data.to_mongo(update=True)
                     ret = yield self.collection.update_one(query, payload)


### PR DESCRIPTION
Looks like there's a `self.required_validate()` missing in `commit` (all drivers) when updating a document.

Fix and tests in the PR.

The first commit added tests about embedded field and list of embedded fields which is unnecessary to test this particular issue, so I "simplified them out". I left them in a separate commit so that they're easy to grab if you find them useful anyway.