### PR TITLE
Fix StrictDateTime issue when using aware datetime as input

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -1,7 +1,7 @@
 from bson import ObjectId, DBRef
 import pytest
 from datetime import datetime
-from dateutil.tz.tz import tzutc
+from dateutil.tz.tz import tzutc, tzoffset
 from marshmallow import ValidationError
 from uuid import UUID
 
@@ -168,8 +168,10 @@ class TestFields(BaseTest):
 
         # Test _deserialize
         s = MySchema(strict=True)
+
         for date in (
             datetime(2016, 8, 6),
+            datetime(2016, 8, 6, tzinfo=tzutc()),
             "2016-08-06T00:00:00Z",
             "2016-08-06T00:00:00",
         ):
@@ -177,12 +179,23 @@ class TestFields(BaseTest):
             assert data['a'] == datetime(2016, 8, 6)
             assert data['b'] == datetime(2016, 8, 6)
             assert data['c'] == datetime(2016, 8, 6, tzinfo=tzutc())
+
+        for date in (
+            "2016-08-06T00:00:00+02:00",
+            datetime(2016, 8, 6, tzinfo=tzoffset(None, 7200)),
+        ):
+            data, _ = s.load({'a': date, 'b': date, 'c': date})
+            assert data['a'] == datetime(2016, 8, 5, 22, 0)
+            assert data['b'] == datetime(2016, 8, 5, 22, 0)
+            assert data['c'] == datetime(2016, 8, 6, tzinfo=tzoffset(None, 7200))
+
         with pytest.raises(ValidationError):
             s.load({'a': "dummy"})
 
         # Test _deserialize_from_mongo
         MyDataProxy = data_proxy_factory('My', MySchema())
         d = MyDataProxy()
+
         for date in (
             datetime(2016, 8, 6),
             datetime(2016, 8, 6, tzinfo=tzutc()),
@@ -191,6 +204,14 @@ class TestFields(BaseTest):
             assert d.get('a') == datetime(2016, 8, 6)
             assert d.get('b') == datetime(2016, 8, 6)
             assert d.get('c') == datetime(2016, 8, 6, tzinfo=tzutc())
+
+        for date in (
+            datetime(2016, 8, 6, tzinfo=tzoffset(None, 7200)),
+        ):
+            d.from_mongo({'a': date, 'b': date, 'c': date})
+            assert d.get('a') == datetime(2016, 8, 5, 22, 0)
+            assert d.get('b') == datetime(2016, 8, 5, 22, 0)
+            assert d.get('c') == datetime(2016, 8, 6, tzinfo=tzoffset(None, 7200))
 
     def test_dict(self):
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -225,7 +225,7 @@ class StrictDateTimeField(BaseField, ma_bonus_fields.StrictDateTime):
         else:
             # If datetime is TZ aware, convert it to UTC and remove TZ info
             if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
-                date.astimezone(tzutc())
+                date = date.astimezone(tzutc())
             date = date.replace(tzinfo=None)
         return date
 

--- a/umongo/marshmallow_bonus.py
+++ b/umongo/marshmallow_bonus.py
@@ -111,7 +111,7 @@ class StrictDateTime(ma_fields.DateTime):
         else:
             # If datetime is TZ aware, convert it to UTC and remove TZ info
             if date.tzinfo is not None and date.tzinfo.utcoffset(date) is not None:
-                date.astimezone(tzutc())
+                date = date.astimezone(tzutc())
             date = date.replace(tzinfo=None)
         return date
 


### PR DESCRIPTION
There was an issue in `StrictDateTime`. I wrote

```py
    date.astimezone(tzutc())
```

which does nothing because astimezone does not modify `date` (a datetime is immutable anyway).

I changed it into

```py
    date = date.astimezone(tzutc())
```

This commit also adds corresponding tests.

Note that I manage the case where we get datetimes from Mongo that are aware and not UTC. This is currently not possible with PyMongo and I doubt it will change anytime soon. I didn't check the other drivers and I guess it is the same there, so we could safely remove those two lines: https://github.com/Nobatek/umongo/blob/fix_strictdatetime_issue/umongo/fields.py#L227-L228.