### PR TITLE
EmbeddedField('string') fails if corresponding EmbeddedDocument is not registered yet

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -8,6 +8,7 @@ from uuid import UUID
 from umongo.data_proxy import data_proxy_factory
 from umongo import Document, EmbeddedDocument, Schema, EmbeddedSchema, fields, Reference
 from umongo.data_objects import List, Dict
+from umongo.exceptions import NotRegisteredDocumentError
 
 from .common import BaseTest
 
@@ -332,6 +333,12 @@ class TestFields(BaseTest):
             embedded_list_a = fields.ListField(
                 fields.EmbeddedField('EmbeddedDocument_A')
             )
+
+        # Can't make Marshmallow Schema before every EmbeddedField is resolved
+        with pytest.raises(NotRegisteredDocumentError):
+            schema = EmbeddedDocument_B.schema.as_marshmallow_schema()
+        with pytest.raises(NotRegisteredDocumentError):
+            schema = EmbeddedDocument_B.schema.fields['embedded_c'].as_marshmallow_field()
 
         @self.instance.register
         class EmbeddedDocument_C(EmbeddedDocument):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -326,13 +326,24 @@ class TestFields(BaseTest):
             field = fields.IntField()
 
         @self.instance.register
-        class EmbeddedDocument_B(EmbeddedDocument):
+        class EmbeddedDocument_B(Document):
             embedded_a = fields.EmbeddedField('EmbeddedDocument_A')
             embedded_c = fields.EmbeddedField('EmbeddedDocument_C')
+            embedded_list_a = fields.ListField(
+                fields.EmbeddedField('EmbeddedDocument_A')
+            )
 
         @self.instance.register
         class EmbeddedDocument_C(EmbeddedDocument):
             field = fields.IntField()
+
+        @self.instance.register
+        class EmbeddedDocument_D(Document):
+            embedded_list_b = fields.ListField(
+                fields.EmbeddedField('EmbeddedDocument_B')
+            )
+            embedded_b = fields.EmbeddedField('EmbeddedDocument_B')
+
 
     def test_complexe_list(self):
 

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -319,6 +319,21 @@ class TestFields(BaseTest):
         repr_d = repr(d.get('list'))
         assert repr_d == "<object umongo.data_objects.List([2, 3, 4, 5])>"
 
+    def test_embedded_field(self):
+
+        @self.instance.register
+        class EmbeddedDocument_A(EmbeddedDocument):
+            field = fields.IntField()
+
+        @self.instance.register
+        class EmbeddedDocument_B(EmbeddedDocument):
+            embedded_a = fields.EmbeddedField('EmbeddedDocument_A')
+            embedded_c = fields.EmbeddedField('EmbeddedDocument_C')
+
+        @self.instance.register
+        class EmbeddedDocument_C(EmbeddedDocument):
+            field = fields.IntField()
+
     def test_complexe_list(self):
 
         @self.instance.register

--- a/umongo/builder.py
+++ b/umongo/builder.py
@@ -190,9 +190,9 @@ class BaseBuilder:
         field.instance = self.instance
         if isinstance(field, ListField):
             self._patch_field(field.container)
-        if isinstance(field, EmbeddedField):
-            for embedded_field in field.schema.fields.values():
-                self._patch_field(embedded_field)
+#        if isinstance(field, EmbeddedField):
+#            for embedded_field in field.schema.fields.values():
+#                self._patch_field(embedded_field)
 
     def _build_schema(self, template, schema_bases, schema_nmspc):
         # Recursively set the `instance` attribute to all fields
@@ -235,7 +235,8 @@ class BaseBuilder:
 
         # _build_document_opts cannot determine the indexes given we need to
         # visit the document's fields which weren't defined at this time
-        opts.indexes = _collect_indexes(nmspc.get('Meta'), schema.fields, bases)
+        #opts.indexes = _collect_indexes(nmspc.get('Meta'), schema.fields, bases)
+        opts.indexes_args = nmspc.get('Meta'), schema.fields, bases
 
         implementation = type(name, bases, nmspc)
         self._templates_lookup[template] = implementation

--- a/umongo/builder.py
+++ b/umongo/builder.py
@@ -11,7 +11,8 @@ from .embedded_document import (
 from .exceptions import DocumentDefinitionError, NotRegisteredDocumentError
 from .schema import Schema, on_need_add_id_field, add_child_field
 from .indexes import parse_index
-from .fields import ListField, EmbeddedField
+# from .fields import ListField, EmbeddedField
+from .fields import ListField
 
 
 def camel_to_snake(name):
@@ -235,7 +236,7 @@ class BaseBuilder:
 
         # _build_document_opts cannot determine the indexes given we need to
         # visit the document's fields which weren't defined at this time
-        #opts.indexes = _collect_indexes(nmspc.get('Meta'), schema.fields, bases)
+        # opts.indexes = _collect_indexes(nmspc.get('Meta'), schema.fields, bases)
         opts.indexes_args = nmspc.get('Meta'), schema.fields, bases
 
         implementation = type(name, bases, nmspc)

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -112,6 +112,7 @@ class DocumentOpts:
 
         return self._indexes
 
+
 class MetaDocumentImplementation(MetaImplementation):
 
     @property

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -95,12 +95,22 @@ class DocumentOpts:
         self.collection_name = collection_name if not abstract else None
         self.abstract = abstract
         self.allow_inheritance = abstract if allow_inheritance is None else allow_inheritance
-        self.indexes = indexes or []
+        self._indexes = indexes or []
+        self._indexes_computed = False
         self.is_child = is_child
         self.offspring = set(offspring) if offspring else set()
         if self.abstract and not self.allow_inheritance:
             raise DocumentDefinitionError("Abstract document cannot disable inheritance")
 
+    @property
+    def indexes(self):
+        if not self._indexes_computed:
+            from .builder import _collect_indexes
+            if getattr(self, 'indexes_args', None):
+                self._indexes = _collect_indexes(*self.indexes_args)
+            self._indexes_computed = True
+
+        return self._indexes
 
 class MetaDocumentImplementation(MetaImplementation):
 


### PR DESCRIPTION
I'm defining an EmbeddedDocument like this:

```py
@db_instance.register
class User(EmbeddedDocument):
    score = fields.EmbeddedField('Score')
```

I provide `Score` as as string because 

- either at import time, the module defining it is not imported yet (and I'd rather avoid it for circular import reasons)

- either it is defined further in the file

Unfortunately, it fails because umongo tries to resolve the EmbeddedDocument right away (no lazyness).

I'm pretty sure you introduced the possibility to use a string precisely for those use cases, right? So I'd call it a bug.

This PR provides a simple failing test.

At import time, `_patch_field` stuff from the builder tries to access `nested` property, which in turns calls `embedded_document_cls` property, which calls `retrieve_embedded_document`.

Traceback:

```
___________________________________________________________________________________________ TestFields.test_embedded_field ___________________________________________________________________________________________

self = <tests.test_fields.TestFields object at 0x7f4cb00f2e10>

    def test_embedded_field(self):
    
        @self.instance.register
        class EmbeddedDocument_A(EmbeddedDocument):
            field = fields.IntField()
    
        @self.instance.register
>       class EmbeddedDocument_B(EmbeddedDocument):

tests/test_fields.py:329: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
umongo/instance.py:103: in register
    implementation = self._register_embedded_doc(template)
umongo/instance.py:117: in _register_embedded_doc
    implementation = self.builder.build_embedded_document_from_template(template)
umongo/builder.py:279: in build_embedded_document_from_template
    schema_cls = self._build_schema(template, schema_bases, schema_nmspc)
umongo/builder.py:200: in _build_schema
    self._patch_field(field)
umongo/builder.py:194: in _patch_field
    for embedded_field in field.schema.fields.values():
../../../.virtualenvs/proleps/lib/python3.4/site-packages/marshmallow/fields.py:391: in schema
    if isinstance(self.nested, SchemaABC):
umongo/fields.py:390: in nested
    return self.embedded_document_cls.Schema
umongo/fields.py:404: in embedded_document_cls
    self.embedded_document)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <umongo.instance.Instance object at 0x7f4cb00f2cf8>, name_or_template = 'EmbeddedDocument_C'

    def retrieve_embedded_document(self, name_or_template):
        """
            Retrieve a :class:`umongo.embedded_document.EmbeddedDocumentImplementation`
            registered into this instance from it name or it template class
            (i.e. :class:`umongo.EmbeddedDocument`).
            """
        if not isinstance(name_or_template, str):
            name_or_template = name_or_template.__name__
        if name_or_template not in self._embedded_lookup:
            raise NotRegisteredDocumentError(
>               'Unknown embedded document class `%s`' % name_or_template)
E           umongo.exceptions.NotRegisteredDocumentError: Unknown embedded document class `EmbeddedDocument_C`

umongo/instance.py:67: NotRegisteredDocumentError
```
