### PR TITLE
Can't copy/deepcopy a Document or EmbeddedDocument

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,5 +1,6 @@
 import pytest
 from datetime import datetime
+from copy import copy, deepcopy
 from bson import ObjectId, DBRef
 
 from umongo import (Document, EmbeddedDocument, Schema, fields, exceptions,
@@ -331,6 +332,14 @@ class TestDocument(BaseTest):
 
         with pytest.raises(NotImplementedError):
             Doc()
+
+    def test_copy(self):
+        john = self.Student(name='John Doe', birthday=datetime(1995, 12, 12), gpa=3.0)
+        copy(john)
+
+    def test_deepcopy(self):
+        john = self.Student(name='John Doe', birthday=datetime(1995, 12, 12), gpa=3.0)
+        deepcopy(john)
 
 
 class TestConfig(BaseTest):

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -1,4 +1,5 @@
 import pytest
+from copy import copy, deepcopy
 from marshmallow import ValidationError
 
 from umongo.data_proxy import data_proxy_factory
@@ -302,3 +303,17 @@ class TestEmbeddedDocument(BaseTest):
                 class Meta:
                     abstract = True
         assert exc.value.args[0] == "Abstract embedded document should have all it parents abstract"
+
+    def test_copy(self):
+        @self.instance.register
+        class MyEmbeddedDocument(EmbeddedDocument):
+            a = fields.IntField()
+        embedded = MyEmbeddedDocument(a=42)
+        copy(embedded)
+
+    def test_deepcopy(self):
+        @self.instance.register
+        class MyEmbeddedDocument(EmbeddedDocument):
+            a = fields.IntField()
+        embedded = MyEmbeddedDocument(a=42)
+        deepcopy(embedded)


### PR DESCRIPTION
I just noticed `Document` and `EmbeddedDocument` break `copy.copy` and `copy.deepcopy`.

Failing tests attached.