### PR TITLE
Add auto_indexes feature to LazyInstance

### DIFF
--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -9,6 +9,7 @@ from ..fixtures import classroom_model, instance
 from umongo import (Document, EmbeddedDocument, fields, exceptions, Reference,
                     Instance, PyMongoInstance, NoDBDefinedError)
 
+from umongo.builder import camel_to_snake
 
 # Check if the required dependancies are met to run this driver's tests
 major, minor, _ = get_pymongo_version()
@@ -562,6 +563,83 @@ class TestPymongo(BaseDBTest):
         UniqueIndexChildDoc.ensure_indexes()
         indexes = [e for e in UniqueIndexChildDoc.collection.list_indexes()]
         assert name_sorted(indexes) == name_sorted(expected_indexes)
+
+    def test_auto_indexes(self, db):
+
+        class ImplicitAutoIndexFalseDoc(Document):
+            name = fields.StrField()
+
+            class Meta:
+                indexes = ['name']
+
+        class ExplicitAutoIndexFalseDoc(Document):
+            name = fields.StrField()
+
+            class Meta:
+                indexes = ['name']
+                auto_indexes = False
+
+        class ExplicitAutoIndexTrueDoc(Document):
+            name = fields.StrField()
+
+            class Meta:
+                indexes = ['name']
+                auto_indexes = True
+
+        def expected_indexes(document, name_index_created):
+
+            ns = '{}.{}'.format(TEST_DB, camel_to_snake(document.__name__))
+            indexes = [
+                {
+                    'key': {'_id': 1},
+                    'name': '_id_',
+                    'ns': ns,
+                    'v': 1
+                },
+            ]
+            if name_index_created:
+                indexes.append(
+                    {
+                        'key': {'name': 1},
+                        'name': 'name_1',
+                        'ns': ns,
+                        'v': 1
+                    }
+                )
+            return indexes
+
+        implicit_auto_indexes_false_instance = PyMongoInstance()
+        explicit_auto_indexes_true_instance = PyMongoInstance(auto_indexes=True)
+        explicit_auto_indexes_false_instance = PyMongoInstance(auto_indexes=False)
+
+        for kwargs in ({}, {'auto_indexes': True}, {'auto_indexes': True}):
+            for document, doc_auto_index in (
+                (ImplicitAutoIndexFalseDoc, False),
+                (ExplicitAutoIndexFalseDoc, False),
+                (ExplicitAutoIndexTrueDoc, True),
+            ):
+                instance = PyMongoInstance(**kwargs)
+                auto_index = kwargs.get('auto_indexes', False) or doc_auto_index
+                Doc = instance.register(document)
+                instance.init(db)
+                # Commit to ensure database is created otherwise list_indexes fails
+                Doc().commit()
+                indexes = [e for e in Doc.collection.list_indexes()]
+                assert name_sorted(indexes) == name_sorted(expected_indexes(Doc, auto_index))
+                Doc.collection.drop()
+                Doc.collection.drop_indexes()
+                instance.ensure_indexes(auto_indexes=False)
+                Doc().commit()
+                indexes = [e for e in Doc.collection.list_indexes()]
+                assert name_sorted(indexes) == name_sorted(expected_indexes(Doc, doc_auto_index))
+                Doc.collection.drop()
+                Doc.collection.drop_indexes()
+                instance.ensure_indexes(auto_indexes=True)
+                Doc().commit()
+                indexes = [e for e in Doc.collection.list_indexes()]
+                assert name_sorted(indexes) == name_sorted(expected_indexes(Doc, True))
+                Doc.collection.drop()
+                Doc.collection.drop_indexes()
 
     def test_inheritance_search(self, instance):
 

--- a/umongo/builder.py
+++ b/umongo/builder.py
@@ -98,6 +98,7 @@ def _build_document_opts(instance, template, name, nmspc, bases):
     kwargs['instance'] = instance
     kwargs['template'] = template
     kwargs['abstract'] = getattr(meta, 'abstract', False)
+    kwargs['auto_indexes'] = getattr(meta, 'auto_indexes', False)
     kwargs['allow_inheritance'] = getattr(meta, 'allow_inheritance', None)
     kwargs['is_child'] = _is_child(bases)
 

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -71,6 +71,7 @@ class DocumentOpts:
                                                 the document into
     is_child             no                     Document inherit of a non-abstract document
     indexes              yes                    List of custom indexes
+    auto_indexes         yes                    Automatically ensure indexes at Instance init
     offspring            no                     List of Documents inheriting this one
     ==================== ====================== ===========
 
@@ -85,17 +86,20 @@ class DocumentOpts:
                 'collection_name={self.collection_name}, '
                 'is_child={self.is_child}, '
                 'indexes={self.indexes}, '
+                'auto_indexes={self.auto_indexes}, '
                 'offspring={self.offspring})>'
                 .format(ClassName=self.__class__.__name__, self=self))
 
     def __init__(self, instance, template, collection_name=None, abstract=False,
-                 allow_inheritance=None, indexes=None, is_child=False, offspring=None):
+                 allow_inheritance=None, indexes=None, is_child=False, offspring=None,
+                 auto_indexes=False):
         self.instance = instance
         self.template = template
         self.collection_name = collection_name if not abstract else None
         self.abstract = abstract
         self.allow_inheritance = abstract if allow_inheritance is None else allow_inheritance
         self.indexes = indexes or []
+        self.auto_indexes = auto_indexes
         self.is_child = is_child
         self.offspring = set(offspring) if offspring else set()
         if self.abstract and not self.allow_inheritance:

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -1,6 +1,6 @@
 from .exceptions import (
     NotRegisteredDocumentError, AlreadyRegisteredDocumentError, NoDBDefinedError)
-from .document import DocumentTemplate, DocumentImplementation
+from .document import DocumentTemplate
 from .template import get_template
 
 


### PR DESCRIPTION
Closes https://github.com/Scille/umongo/issues/81.

What do you think about this ?

It works only on documents that are already registered when calling `instance.init()`.

TODO:

- [ ] Add tests for drivers other than PyMongo (currently only PyMongo is tested)

- [ ] Document the feature

- [ ] Also ensure indexes on documents registered after `instance.init()`?