### PR TITLE
Fix allow none in DataProxy.set

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -113,10 +113,11 @@ class TestDataProxy(BaseTest):
         class MySchema(EmbeddedSchema):
             a = fields.IntField()
             b = fields.IntField(attribute='in_mongo_b')
-            c = fields.IntField(
+            c = fields.StrField(
                 allow_none=True,
-                validate=validate.Range(min=1, max=5)
+                validate=validate.Length(min=1, max=5)
             )
+            d = fields.StrField()
 
         MyDataProxy = data_proxy_factory('My', MySchema())
         d = MyDataProxy()
@@ -137,7 +138,9 @@ class TestDataProxy(BaseTest):
         d.set('c', None)
         assert d.to_mongo() == {'c': None}
         with pytest.raises(ValidationError):
-            d.set('c', 69)
+            d.set('c', '123456')
+        with pytest.raises(ValidationError):
+            d.set('d', None)
 
     def test_del(self):
 

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -144,8 +144,10 @@ class BaseDataProxy:
 
     def set(self, name, value, to_raise=KeyError):
         name, field = self._get_field(name, to_raise)
-        value = field._deserialize(value, name, None)
-        if value is not None or not getattr(field, 'allow_none', False):
+        if value is None and not getattr(field, 'allow_none', False):
+            raise ValidationError(field.error_messages['null'])
+        if value is not None:
+            value = field._deserialize(value, name, None)
             field._validate(value)
         self._data[name] = value
         self._mark_as_modified(name)


### PR DESCRIPTION
My [earlier modifications to `set`](https://github.com/Scille/umongo/pull/63) left uncovered cases.

In marshmallow, the case where value is None and field.allow_none is False is managed in [`_validate_missing`](https://github.com/marshmallow-code/marshmallow/blob/dev/marshmallow/fields.py#L229), which we skip. So we need to do that ourselves here.

Without this fix,
- we call `_deserialize` on any data, even None, which yields ValidationError on legit inputs
- ValidationError when value is None and allow_None is False does not return the ['null'] message