### PR TITLE
Pass as marshmallow schema params to nested schemas

### DIFF
--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -204,6 +204,33 @@ class TestMarshmallow(BaseTest):
         assert not ret.errors
         assert ret.data == bag.to_mongo()
 
+        # Check as_marshmallow_schema params (check_unknown_felds, base_schema_cls)
+        # are passed to nested schemas
+        data = {
+            'id': {'brief': 'sportbag', 'value': 100, 'name': 'Unknown'},
+            'content': [
+                {'brief': 'cellphone', 'value': 500, 'name': 'Unknown'},
+                {'brief': 'lighter', 'value': 2, 'name': 'Unknown'}]
+        }
+        ret = ma_schema.load(data)
+        assert ret.errors == {
+            'id': {'_schema': ['Unknown field name name.']},
+            'content': {
+                0: {'_schema': ['Unknown field name name.']},
+                1: {'_schema': ['Unknown field name name.']},
+            }}
+
+        ma_no_check_unknown_schema = Bag.schema.as_marshmallow_schema(check_unknown_fields=False)()
+        ret = ma_no_check_unknown_schema.load(data)
+        assert not ret.errors
+
+        class WithNameSchema(marshmallow.Schema):
+            name = marshmallow.fields.Str()
+
+        ma_custom_base_schema = Bag.schema.as_marshmallow_schema(base_schema_cls=WithNameSchema)()
+        ret = ma_custom_base_schema.load(data)
+        assert not ret.errors
+
     def test_marshmallow_bonus_fields(self):
         # Fields related to mongodb provided for marshmallow
         @self.instance.register

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -191,8 +191,7 @@ class BaseField(ma_fields.Field):
         params.update(self.metadata)
         return params
 
-    def as_marshmallow_field(self, params=None, base_schema_cls=MaSchema,
-                             check_unknown_fields=True, mongo_world=False):
+    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
         """
         Return a pure-marshmallow version of this field.
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 
 from marshmallow import ValidationError, missing
-from marshmallow import fields as ma_fields, Schema as MaSchema
+from marshmallow import fields as ma_fields
 from bson import DBRef, ObjectId
 
 # from .registerer import retrieve_document
@@ -108,17 +108,14 @@ class ListField(BaseField, ma_fields.List):
         if hasattr(self.container, 'map_to_field'):
             self.container.map_to_field(mongo_path, path, func)
 
-    def as_marshmallow_field(self, params=None, base_schema_cls=MaSchema,
-                             check_unknown_fields=True, mongo_world=False):
+    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle deserialization
         # difference (`_id` vs `id`)
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
         if params:
             field_kwargs.update(params)
         return ma_fields.List(self.container.as_marshmallow_field(
-            base_schema_cls=base_schema_cls,
-            check_unknown_fields=check_unknown_fields,
-            mongo_world=mongo_world), **field_kwargs)
+            mongo_world=mongo_world, **kwargs), **field_kwargs)
 
     def _required_validate(self, value):
         if value is missing or not hasattr(self.container, '_required_validate'):
@@ -490,8 +487,7 @@ class EmbeddedField(BaseField, ma_fields.Nested):
             if hasattr(field, 'map_to_field'):
                 field.map_to_field(cur_mongo_path, cur_path, func)
 
-    def as_marshmallow_field(self, params=None, base_schema_cls=MaSchema,
-                             check_unknown_fields=True, mongo_world=False):
+    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle nesting
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
         if params:
@@ -500,10 +496,7 @@ class EmbeddedField(BaseField, ma_fields.Nested):
         else:
             nested_params = None
         nested_ma_schema = self._embedded_document_cls.schema.as_marshmallow_schema(
-            params=nested_params,
-            base_schema_cls=base_schema_cls,
-            check_unknown_fields=check_unknown_fields,
-            mongo_world=mongo_world)
+            params=nested_params, mongo_world=mongo_world, **kwargs)
         return ma_fields.Nested(nested_ma_schema, **field_kwargs)
 
     def _required_validate(self, value):

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -495,8 +495,10 @@ class EmbeddedField(BaseField, ma_fields.Nested):
             field_kwargs.update(params)
         else:
             nested_params = None
+        schema_kwargs = {k: v for k, v in kwargs.items()
+                         if k in ('base_schema_cls', 'check_unknown_fields')}
         nested_ma_schema = self._embedded_document_cls.schema.as_marshmallow_schema(
-            params=nested_params, mongo_world=mongo_world, **kwargs)
+            params=nested_params, mongo_world=mongo_world, **schema_kwargs)
         return ma_fields.Nested(nested_ma_schema, **field_kwargs)
 
     def _required_validate(self, value):


### PR DESCRIPTION
Parameters of `as_marshmallow_schema` should be passed to nested Schemas.

In this implementation, I pass them to all fields, so that `EmbeddedField` gets it and pass it when calling `as_marshmallow_schema`.

Nothing really complicated here. I had to modify `as_marshmallow_field`'s signature, hence the modifications in unrelated fields.

Note that I changed `kwargs` into `field_kwargs` in those fields to make it obvious to the reader it is not the same `kwargs` we're talking about. It would work without the rename, but it would look like a mistake at first sight:

```python
    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
        # Oh, we're overwriting kwargs! Let's file a bug!
        kwargs = self._extract_marshmallow_field_params(mongo_world)
```

Another option was to use `_` but I'm not sure it is so common for kwargs:

```python
    def as_marshmallow_field(self, params=None, mongo_world=False, **_):
        kwargs = self._extract_marshmallow_field_params(mongo_world)
```

I preferred to rename the field kwargs inside the method:

```python
    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
        field_kwargs = self._extract_marshmallow_field_params(mongo_world)
```

I could rework this if you have a better idea.

This PR does _not_ address those two related issues I assigned myself a while ago: https://github.com/Scille/umongo/issues/64, https://github.com/Scille/umongo/issues/65...