### PR TITLE
Fix equality tests

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -206,6 +206,11 @@ class TestDataProxy(BaseTest):
         d2.load({'a': 1, 'b': 2})
         assert d1 == d2
 
+        assert d1 != None  # noqa: E711 (None comparison)
+        assert d1 != missing
+        assert None != d1
+        assert missing != d1
+
     def test_share_ressources(self):
 
         class MySchema(EmbeddedSchema):

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -1,5 +1,5 @@
 import pytest
-from marshmallow import ValidationError
+from marshmallow import ValidationError, missing
 
 from umongo.data_proxy import data_proxy_factory
 from umongo import Document, EmbeddedDocument, fields, exceptions
@@ -321,3 +321,25 @@ class TestEmbeddedDocument(BaseTest):
                 class Meta:
                     abstract = True
         assert exc.value.args[0] == "Abstract embedded document should have all it parents abstract"
+
+    def test_equality(self):
+        @self.instance.register
+        class MyChildEmbeddedDocument(EmbeddedDocument):
+            num = fields.IntField()
+
+        @self.instance.register
+        class MyParentEmbeddedDocument(EmbeddedDocument):
+            embedded = fields.EmbeddedField(MyChildEmbeddedDocument)
+
+        emb_1 = MyParentEmbeddedDocument(embedded={'num': 1})
+        emb_2 = MyParentEmbeddedDocument(embedded={'num': 1})
+        emb_3 = MyParentEmbeddedDocument(embedded={})
+        emb_4 = MyParentEmbeddedDocument()
+
+        assert emb_1 == emb_2
+        assert emb_1 != emb_3
+        assert emb_1 != emb_4
+        assert emb_1 != None  # noqa: E711 (None comparison)
+        assert emb_1 != missing
+        assert None != emb_1
+        assert missing != emb_1

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -164,8 +164,9 @@ class BaseDataProxy:
     def __eq__(self, other):
         if isinstance(other, dict):
             return self._data == other
-        else:
+        elif hasattr(other, '_data'):
             return self._data == other._data
+        return NotImplemented
 
     def get_modified_fields_by_mongo_name(self):
         return self._modified_data

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -103,8 +103,9 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
     def __eq__(self, other):
         if isinstance(other, dict):
             return self._data == other
-        else:
+        elif hasattr(other, '_data'):
             return self._data == other._data
+        return NotImplemented
 
     def is_modified(self):
         return self._data.is_modified()


### PR DESCRIPTION
I've been having issues when comparing `EmbeddedDocument`s with nesting.

Sometimes, the nested field is not an `EmbeddedDocument` but `missing` or `None`, and the comparison fails raising `AttributeError` because `other._data` does not exist.

I tried to cover theses cases and maybe I'm covering a bit larger, but I don't think it should be an issue.