### PR TITLE
Rework StrictDateTime

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -4,6 +4,8 @@ History
 
 dev
 ---
+* Fix StrictDateTime bonus field: _deserialize does not accept datetime.datetime
+  instances (see #106)
 * Add force_reload param to Reference.fetch (see #96)
 
 0.13.0 (2017-03-03)

--- a/umongo/marshmallow_bonus.py
+++ b/umongo/marshmallow_bonus.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from dateutil.tz import tzutc
 
 from marshmallow import ValidationError, Schema as MaSchema, missing
@@ -100,10 +99,10 @@ class StrictDateTime(ma_fields.DateTime):
         self.load_as_tz_aware = load_as_tz_aware
 
     def _deserialize(self, value, attr, data):
-        if isinstance(value, datetime):
-            date = value
-        else:
-            date = super()._deserialize(value, attr, data)
+        date = super()._deserialize(value, attr, data)
+        return self._set_tz_awareness(date)
+
+    def _set_tz_awareness(self, date):
         if self.load_as_tz_aware:
             # If datetime is TZ naive, set UTC timezone
             if date.tzinfo is None or date.tzinfo.utcoffset(date) is None:


### PR DESCRIPTION
This commit

- factorizes the TZ awareness enforcement logic (I wonder why I didn't do that right away...)

- makes `StrictDateTime` bonus field reject `datetime.datetime` instances, which is coherent with `DateTime`. Accepting `datetime.datetime` instances is done in umongo's `StrictDateTimeField` only, just like with `DateTimeField`.

Should I had test for this?