### PR TITLE
Fix deletion of field proxied by a property

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -117,6 +117,29 @@ class TestDocument(BaseTest):
         with pytest.raises(KeyError):
             del john['missing']
 
+    def test_property(self):
+        @self.instance.register
+        class HeavyStudent(BaseStudent):
+            _weight = fields.FloatField()
+
+            @property
+            def weight(self):
+                return self._weight
+
+            @weight.setter
+            def weight(self, value):
+                self._weight = value
+
+            @weight.deleter
+            def weight(self):
+                del self._weight
+
+        john = HeavyStudent()
+        john.weight = 42
+        assert john.weight == 42
+        del john.weight
+        assert john.weight is None
+
     def test_pk(self):
         john = self.Student.build_from_mongo(data={
             'name': 'John Doe', 'birthday': datetime(1995, 12, 12), 'gpa': 3.0})

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -280,7 +280,12 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
         return value if value is not missing else None
 
     def __delattr__(self, name):
-        self._data.delete(name, to_raise=AttributeError)
+        if not self.__real_attributes:
+            type(self).__real_attributes = dir(self)
+        if name in self.__real_attributes:
+            object.__delattr__(self, name)
+        else:
+            self._data.delete(name, to_raise=AttributeError)
 
     # Callbacks
 


### PR DESCRIPTION
Like `__setattr__`, `__delattr__` should only get to the DataProxy for fields, not other attributes. Otherwise, when a field is proxied by a property, its deletion fails.