### PR TITLE
Fix ReferenceField in EmbeddedDocument assignment

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -463,6 +463,12 @@ class TestFields(BaseTest):
         with pytest.raises(ValidationError):
             d.set('ref', bad_ref)
 
+        # Test from_mongo behavior with already deserialized data
+        d2 = MyDataProxy()
+        d2.from_mongo({
+            'in_mongo_ref': Reference(MyReferencedDoc, ObjectId("5672d47b1d41c88dcd37ef05"))})
+        assert not isinstance(d2._data['in_mongo_ref'].pk, Reference)
+
     def test_reference_lazy(self):
 
         @self.instance.register
@@ -538,3 +544,9 @@ class TestFields(BaseTest):
         ]:
             with pytest.raises(ValidationError):
                 d.set('gref', v)
+
+        # Test from_mongo behavior with already deserialized data
+        d2 = MyDataProxy()
+        d2.from_mongo({
+            'in_mongo_gref': Reference(ToRef1, ObjectId("5672d47b1d41c88dcd37ef05"))})
+        assert not isinstance(d2._data['in_mongo_gref'].pk, Reference)

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -290,6 +290,10 @@ class ReferenceField(BaseField, ma_bonus_fields.Reference):
         return obj.pk
 
     def _deserialize_from_mongo(self, value):
+        # When this method is called from `_deserialize`, `value` can be
+        # already deserialized, in such a case do nothing.
+        if isinstance(value, self.reference_cls):
+            return value
         return self.reference_cls(self.document_cls, value)
 
     def as_marshmallow_field(self, params=None, mongo_world=False):
@@ -345,6 +349,10 @@ class GenericReferenceField(BaseField, ma_bonus_fields.GenericReference):
         return {'_id': obj.pk, '_cls': obj.document_cls.__name__}
 
     def _deserialize_from_mongo(self, value):
+        # When this method is called from `_deserialize`, `value` can be
+        # already deserialized, in such a case do nothing.
+        if isinstance(value, self.reference_cls):
+            return value
         try:
             document_cls = self.instance.retrieve_document(value['_cls'])
         except NotRegisteredDocumentError:


### PR DESCRIPTION
I had a helluva time debugging this one...

Assume you have a `ReferenceField` in an `EmbeddedDocument`. Now try to change the value of the embedded document in the document, like this:

    my_doc.embedded_doc = new_embedded_doc

You get into troubles, with a messed up reference field.

The issue here is related to the use of `_deserialize_from_mongo` as you explain [in this comment](https://github.com/Scille/umongo/pull/84#issuecomment-268840412).

Since `EmbeddedField._deserialize` calls `_deserialize_from_mongo`, we end up calling `deserialize_from_mongo` on the reference field with data that is already deserialized, so we pass that deserialization method a `Reference` while it expects an `ObjectID` (or a string representation of an `ObjectId`).

Since `Reference.__init__()` does not check its pk, we end up with a `Reference` object that looks like this:

        <object umongo.data_objects.Reference(document=MyReferencedDoc, pk=<object umongo.data_objects.Reference(document=MyReferencedDoc, pk=ObjectId('5672d47b1d41c88dcd37ef05'))>)>

which doesn't make sense, instead of expected

    <object umongo.data_objects.Reference(document=MyReferencedDoc, pk=ObjectId('5672d47b1d41c88dcd37ef05'))>

At first, I thought of modifying `Reference.__init__` to accept either another `Reference` instance or an ID, but this should be handled by the field, not the data object, so here's the fix I propose.

I also modified `GenericReferenceField` the same way. In this case, the symptom was different, it would crash on deserialization while trying to get `value['_cls']` with `value` being a `Reference` object.