### PR TITLE
Fix Py34 Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ env:
 - DRIVER=txmongo
 before_install:
 - mongo --version
+- pip install -U six
 install:
 - pip install -U tox
 - pip install -U coveralls


### PR DESCRIPTION
The same workaround was applied to marshmallow: https://github.com/marshmallow-code/marshmallow/commit/6aba50cf109b7c39c9e3e6631911f1892418898b.

