### PR TITLE
fix error due to typo in flask example

### DIFF
--- a/examples/flask/app.py
+++ b/examples/flask/app.py
@@ -130,7 +130,7 @@ def update_user(nick_or_id):
     if not user:
         abort(404)
     # Define a custom schema from the default one to ignore read-only fields
-    UserUpdateSchema = User.Schema.as_marshmallow_schema(params={
+    UserUpdateSchema = User.schema.as_marshmallow_schema(params={
         'password': {'dump_only': True},
         'nick': {'dump_only': True}
     })()


### PR DESCRIPTION
- fixes `TypeError: as_marshmallow_schema() missing 1 required positional argument: 'self'`