### PR TITLE
Fix CI tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -15,7 +15,7 @@ replace = __version__ = '{new_version}'
 universal = 1
 
 [flake8]
-ignore = E127,E128
+ignore = E127,E128,W504
 max-line-length = 100
 exclude = .git,docs,restkit/compat.py,env,venv,.ropeproject,_sandbox,tests,examples
 

--- a/tests/frameworks/test_mongomock.py
+++ b/tests/frameworks/test_mongomock.py
@@ -15,10 +15,13 @@ if not dep_error:  # Make sure the module is valid by importing it
     from umongo.frameworks import mongomock
 
 
-# Used by fixtures.py
+def make_db():
+    return MongoClient()[TEST_DB]
+
+
 @pytest.fixture
 def db():
-    return MongoClient()[TEST_DB]
+    return make_db()
 
 
 # MongoMockBuilder is 100% based on PyMongoBuilder so no need for really heavy tests

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -26,10 +26,13 @@ def _ns_stripped(indexes):
     return {k: {sk: sv for sk, sv in v.items() if sk != 'ns'} for k, v in indexes.items()}
 
 
-# Used by fixtures.py
+def make_db():
+    return AsyncIOMotorClient()[TEST_DB]
+
+
 @pytest.fixture
 def db():
-    return AsyncIOMotorClient()[TEST_DB]
+    return make_db()
 
 
 @pytest.fixture

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -20,10 +20,15 @@ if not dep_error:  # Make sure the module is valid by importing it
     from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
 
 
-def _ns_stripped(indexes):
+def _stripped(indexes):
     # With pymongo==2.8 a `ns` field is returned with Mongodb>=3 but
     # not with MongoDB<2, thus we have to clean this before doing comparing
-    return {k: {sk: sv for sk, sv in v.items() if sk != 'ns'} for k, v in indexes.items()}
+    # Version may differ between database versions and configurations so it
+    # shall not be checked
+    return {
+        k: {sk: sv for sk, sv in v.items() if sk not in ('ns', 'v')}
+        for k, v in indexes.items()
+    }
 
 
 def make_db():
@@ -469,19 +474,17 @@ class TestMotorAsyncio(BaseDBTest):
             expected_indexes = {
                 '_id_': {
                     'key': [('_id', 1)],
-                    'v': 1
                 },
                 'indexed_1': {
                     'key': [('indexed', 1)],
-                    'v': 1
                 }
             }
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
             # Redoing indexes building should do nothing
             yield from SimpleIndexDoc.ensure_indexes()
             indexes = yield from SimpleIndexDoc.collection.index_information()
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
         loop.run_until_complete(do_test())
 
@@ -507,19 +510,17 @@ class TestMotorAsyncio(BaseDBTest):
             expected_indexes = {
                 '_id_': {
                     'key': [('_id', 1)],
-                    'v': 1
                 },
                 'indexed_1': {
                     'key': [('indexed', 1)],
-                    'v': 1
                 }
             }
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
             # Redoing indexes building should do nothing
             yield from SimpleIndexDoc.ensure_indexes()
             indexes = yield from SimpleIndexDoc.collection.index_information()
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
         loop.run_until_complete(do_test())
 
@@ -546,26 +547,23 @@ class TestMotorAsyncio(BaseDBTest):
             expected_indexes = {
                 '_id_': {
                     'key': [('_id', 1)],
-                    'v': 1
                 },
                 'required_unique_1': {
-                    'v': 1,
                     'key': [('required_unique', 1)],
                     'unique': True
                 },
                 'sparse_unique_1': {
-                    'v': 1,
                     'key': [('sparse_unique', 1)],
                     'unique': True,
                     'sparse': True
                 }
             }
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
             # Redoing indexes building should do nothing
             yield from UniqueIndexDoc.ensure_indexes()
             indexes = yield from UniqueIndexDoc.collection.index_information()
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
             yield from UniqueIndexDoc(not_unique='a', required_unique=1).commit()
             yield from UniqueIndexDoc(not_unique='a', sparse_unique=1, required_unique=2).commit()
@@ -605,22 +603,20 @@ class TestMotorAsyncio(BaseDBTest):
             expected_indexes = {
                 '_id_': {
                     'key': [('_id', 1)],
-                    'v': 1
                 },
                 'compound1_1_compound2_1': {
-                    'v': 1,
                     'key': [('compound1', 1), ('compound2', 1)],
                     'unique': True
                 }
             }
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
             # Redoing indexes building should do nothing
             yield from UniqueIndexCompoundDoc.ensure_indexes()
             indexes = yield from UniqueIndexCompoundDoc.collection.index_information()
             # Must sort compound indexes to avoid random inconsistence
             indexes['compound1_1_compound2_1']['key'] = sorted(indexes['compound1_1_compound2_1']['key'])
-            assert _ns_stripped(indexes) == expected_indexes
+            assert _stripped(indexes) == expected_indexes
 
             # Index is on the tuple (compound1, compound2)
             yield from UniqueIndexCompoundDoc(not_unique='a', compound1=1, compound2=1).commit()
@@ -676,30 +672,25 @@ class TestMotorAsyncio(BaseDBTest):
                     'key': {'_id': 1},
                     'name': '_id_',
                     'ns': '%s.unique_index_inheritance_doc' % TEST_DB,
-                    'v': 1
                 },
                 {
-                    'v': 1,
                     'key': {'unique': 1},
                     'name': 'unique_1',
                     'unique': True,
                     'ns': '%s.unique_index_inheritance_doc' % TEST_DB
                 },
                 {
-                    'v': 1,
                     'key': {'manual_index': 1, '_cls': 1},
                     'name': 'manual_index_1__cls_1',
                     'ns': '%s.unique_index_inheritance_doc' % TEST_DB
                 },
                 {
-                    'v': 1,
                     'key': {'_cls': 1},
                     'name': '_cls_1',
                     'unique': True,
                     'ns': '%s.unique_index_inheritance_doc' % TEST_DB
                 },
                 {
-                    'v': 1,
                     'key': {'child_unique': 1, '_cls': 1},
                     'name': 'child_unique_1__cls_1',
                     'unique': True,

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -25,10 +25,13 @@ def name_sorted(indexes):
     return sorted(indexes, key=lambda x: x['name'])
 
 
-# Used by fixtures.py
+def make_db():
+    return MongoClient()[TEST_DB]
+
+
 @pytest.fixture
 def db():
-    return MongoClient()[TEST_DB]
+    return make_db()
 
 
 @pytest.mark.skipif(dep_error is not None, reason=dep_error)

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -20,6 +20,13 @@ if not dep_error:  # Make sure the module is valid by importing it
     from umongo.frameworks import pymongo as framework_pymongo
 
 
+def _stripped(indexes):
+    # Version may differ between database versions and configurations so it shall not be checked
+    for idx in indexes:
+        idx.pop('v')
+    return indexes
+
+
 # Helper to sort indexes by name in order to have deterministic comparison
 def name_sorted(indexes):
     return sorted(indexes, key=lambda x: x['name'])
@@ -324,26 +331,25 @@ class TestPymongo(BaseDBTest):
 
         # Now ask for indexes building
         SimpleIndexDoc.ensure_indexes()
-        indexes = [e for e in SimpleIndexDoc.collection.list_indexes()]
+        indexes = list(SimpleIndexDoc.collection.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.simple_index_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'indexed': 1},
                 'name': 'indexed_1',
                 'ns': '%s.simple_index_doc' % TEST_DB
             }
         ]
-        assert indexes == expected_indexes
+        assert _stripped(indexes) == expected_indexes
 
         # Redoing indexes building should do nothing
         SimpleIndexDoc.ensure_indexes()
-        assert indexes == expected_indexes
+        indexes = list(SimpleIndexDoc.collection.list_indexes())
+        assert _stripped(indexes) == expected_indexes
 
     def test_indexes_inheritance(self, instance):
 
@@ -359,26 +365,25 @@ class TestPymongo(BaseDBTest):
 
         # Now ask for indexes building
         SimpleIndexDoc.ensure_indexes()
-        indexes = [e for e in SimpleIndexDoc.collection.list_indexes()]
+        indexes = list(SimpleIndexDoc.collection.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.simple_index_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'indexed': 1},
                 'name': 'indexed_1',
                 'ns': '%s.simple_index_doc' % TEST_DB
             }
         ]
-        assert indexes == expected_indexes
+        assert _stripped(indexes) == expected_indexes
 
         # Redoing indexes building should do nothing
         SimpleIndexDoc.ensure_indexes()
-        assert indexes == expected_indexes
+        indexes = list(SimpleIndexDoc.collection.list_indexes())
+        assert _stripped(indexes) == expected_indexes
 
     def test_unique_index(self, instance):
 
@@ -393,23 +398,20 @@ class TestPymongo(BaseDBTest):
 
         # Now ask for indexes building
         UniqueIndexDoc.ensure_indexes()
-        indexes = [e for e in UniqueIndexDoc.collection.list_indexes()]
+        indexes = list(UniqueIndexDoc.collection.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.unique_index_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'required_unique': 1},
                 'name': 'required_unique_1',
                 'unique': True,
                 'ns': '%s.unique_index_doc' % TEST_DB
             },
             {
-                'v': 1,
                 'key': {'sparse_unique': 1},
                 'name': 'sparse_unique_1',
                 'unique': True,
@@ -417,12 +419,12 @@ class TestPymongo(BaseDBTest):
                 'ns': '%s.unique_index_doc' % TEST_DB
             },
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         UniqueIndexDoc.ensure_indexes()
-        indexes = [e for e in UniqueIndexDoc.collection.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(UniqueIndexDoc.collection.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         UniqueIndexDoc(not_unique='a', required_unique=1).commit()
         UniqueIndexDoc(not_unique='a', sparse_unique=1, required_unique=2).commit()
@@ -450,28 +452,26 @@ class TestPymongo(BaseDBTest):
 
         # Now ask for indexes building
         UniqueIndexCompoundDoc.ensure_indexes()
-        indexes = [e for e in UniqueIndexCompoundDoc.collection.list_indexes()]
+        indexes = list(UniqueIndexCompoundDoc.collection.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.unique_index_compound_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'compound1': 1, 'compound2': 1},
                 'name': 'compound1_1_compound2_1',
                 'unique': True,
                 'ns': '%s.unique_index_compound_doc' % TEST_DB
             }
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         UniqueIndexCompoundDoc.ensure_indexes()
-        indexes = [e for e in UniqueIndexCompoundDoc.collection.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(UniqueIndexCompoundDoc.collection.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Index is on the tuple (compound1, compound2)
         UniqueIndexCompoundDoc(not_unique='a', compound1=1, compound2=1).commit()
@@ -515,48 +515,43 @@ class TestPymongo(BaseDBTest):
 
         # Now ask for indexes building
         UniqueIndexChildDoc.ensure_indexes()
-        indexes = [e for e in UniqueIndexChildDoc.collection.list_indexes()]
+        indexes = list(UniqueIndexChildDoc.collection.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.unique_index_inheritance_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'unique': 1},
                 'name': 'unique_1',
                 'unique': True,
                 'ns': '%s.unique_index_inheritance_doc' % TEST_DB
             },
             {
-                'v': 1,
                 'key': {'manual_index': 1, '_cls': 1},
                 'name': 'manual_index_1__cls_1',
                 'ns': '%s.unique_index_inheritance_doc' % TEST_DB
             },
             {
-                'v': 1,
                 'key': {'_cls': 1},
                 'name': '_cls_1',
                 'unique': True,
                 'ns': '%s.unique_index_inheritance_doc' % TEST_DB
             },
             {
-                'v': 1,
                 'key': {'child_unique': 1, '_cls': 1},
                 'name': 'child_unique_1__cls_1',
                 'unique': True,
                 'ns': '%s.unique_index_inheritance_doc' % TEST_DB
             }
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         UniqueIndexChildDoc.ensure_indexes()
-        indexes = [e for e in UniqueIndexChildDoc.collection.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(UniqueIndexChildDoc.collection.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
     def test_inheritance_search(self, instance):
 

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -46,10 +46,13 @@ def name_sorted(indexes):
     return sorted(indexes, key=lambda x: x['name'])
 
 
-# Used by fixtures.py
+def make_db():
+    return MongoConnection()[TEST_DB]
+
+
 @pytest.fixture
 def db():
-    return MongoConnection()[TEST_DB]
+    return make_db()
 
 
 @pytest.mark.skipif(dep_error is not None, reason=dep_error)

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -46,6 +46,13 @@ def name_sorted(indexes):
     return sorted(indexes, key=lambda x: x['name'])
 
 
+def _stripped(indexes):
+    # Version may differ between database versions and configurations so it shall not be checked
+    for idx in indexes:
+        idx.pop('v')
+    return indexes
+
+
 def make_db():
     return MongoConnection()[TEST_DB]
 
@@ -399,27 +406,25 @@ class TestTxMongo(BaseDBTest):
         # Now ask for indexes building
         yield SimpleIndexDoc.ensure_indexes()
         # SimpleIndexDoc.collection.index_information doesn't seems to work...
-        indexes = [e for e in con[TEST_DB].simple_index_doc.list_indexes()]
+        indexes = list(con[TEST_DB].simple_index_doc.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.simple_index_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'indexed': 1},
                 'name': 'indexed_1',
                 'ns': '%s.simple_index_doc' % TEST_DB
             }
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         yield SimpleIndexDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].simple_index_doc.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(con[TEST_DB].simple_index_doc.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
     @pytest_inlineCallbacks
     def test_indexes_inheritance(self, instance):
@@ -438,27 +443,25 @@ class TestTxMongo(BaseDBTest):
         # Now ask for indexes building
         yield SimpleIndexDoc.ensure_indexes()
         # SimpleIndexDoc.collection.index_information doesn't seems to work...
-        indexes = [e for e in con[TEST_DB].simple_index_doc.list_indexes()]
+        indexes = list(con[TEST_DB].simple_index_doc.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.simple_index_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'indexed': 1},
                 'name': 'indexed_1',
                 'ns': '%s.simple_index_doc' % TEST_DB
             }
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         yield SimpleIndexDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].simple_index_doc.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(con[TEST_DB].simple_index_doc.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
     @pytest_inlineCallbacks
     def test_unique_index(self, instance):
@@ -477,23 +480,20 @@ class TestTxMongo(BaseDBTest):
 
         # Now ask for indexes building
         yield UniqueIndexDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].unique_index_doc.list_indexes()]
+        indexes = list(con[TEST_DB].unique_index_doc.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.unique_index_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'required_unique': 1},
                 'name': 'required_unique_1',
                 'unique': True,
                 'ns': '%s.unique_index_doc' % TEST_DB
             },
             {
-                'v': 1,
                 'key': {'sparse_unique': 1},
                 'name': 'sparse_unique_1',
                 'unique': True,
@@ -501,12 +501,12 @@ class TestTxMongo(BaseDBTest):
                 'ns': '%s.unique_index_doc' % TEST_DB
             },
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         yield UniqueIndexDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].unique_index_doc.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(con[TEST_DB].unique_index_doc.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         yield UniqueIndexDoc(not_unique='a', required_unique=1).commit()
         yield UniqueIndexDoc(not_unique='a', sparse_unique=1, required_unique=2).commit()
@@ -536,28 +536,26 @@ class TestTxMongo(BaseDBTest):
 
         # Now ask for indexes building
         yield UniqueIndexCompoundDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].unique_index_compound_doc.list_indexes()]
+        indexes = list(con[TEST_DB].unique_index_compound_doc.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
                 'name': '_id_',
                 'ns': '%s.unique_index_compound_doc' % TEST_DB,
-                'v': 1
             },
             {
-                'v': 1,
                 'key': {'compound1': 1, 'compound2': 1},
                 'name': 'compound1_1_compound2_1',
                 'unique': True,
                 'ns': '%s.unique_index_compound_doc' % TEST_DB
             }
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         yield UniqueIndexCompoundDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].unique_index_compound_doc.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(con[TEST_DB].unique_index_compound_doc.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Index is on the tuple (compound1, compound2)
         yield UniqueIndexCompoundDoc(not_unique='a', compound1=1, compound2=1).commit()
@@ -603,7 +601,7 @@ class TestTxMongo(BaseDBTest):
 
         # Now ask for indexes building
         yield UniqueIndexChildDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].unique_index_inheritance_doc.list_indexes()]
+        indexes = list(con[TEST_DB].unique_index_inheritance_doc.list_indexes())
         expected_indexes = [
             {
                 'key': {'_id': 1},
@@ -639,12 +637,12 @@ class TestTxMongo(BaseDBTest):
                 'ns': '%s.unique_index_inheritance_doc' % TEST_DB
             }
         ]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
         # Redoing indexes building should do nothing
         yield UniqueIndexChildDoc.ensure_indexes()
-        indexes = [e for e in con[TEST_DB].unique_index_inheritance_doc.list_indexes()]
-        assert name_sorted(indexes) == name_sorted(expected_indexes)
+        indexes = list(con[TEST_DB].unique_index_inheritance_doc.list_indexes())
+        assert name_sorted(_stripped(indexes)) == name_sorted(expected_indexes)
 
     @pytest_inlineCallbacks
     def test_inheritance_search(self, instance):

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -20,7 +20,7 @@ for name, inst in (('mongomock', MongoMockInstance),
                    ('pymongo', PyMongoInstance)):
     mod = importlib.import_module('tests.frameworks.test_%s' % name)
     if not mod.dep_error:
-        DB_AND_INSTANCE_PER_FRAMEWORK.append((mod.db(), inst))
+        DB_AND_INSTANCE_PER_FRAMEWORK.append((mod.make_db(), inst))
 
 
 @pytest.fixture(params=DB_AND_INSTANCE_PER_FRAMEWORK)


### PR DESCRIPTION
- Update flake8 config to ignore W504 (see rationale in https://github.com/marshmallow-code/apispec/pull/322).
- Don't call fixtures directly, which is forbidden with pytest 4.
- Don't test index version. The index version depends on the database version (and configuration). It should not be tested here. This breaks the CI tests as they are now run on MongoDB 3.4 which default to v2.