### PR TITLE
Make pymongo a mandatory dependency (it is needed for bson)

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,4 +1,3 @@
-pymongo  # needed for bson module
 bumpversion
 wheel
 flake8

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ with open('HISTORY.rst', 'rb') as history_file:
 
 requirements = [
     "marshmallow>=2.6.0",
-    "python-dateutil>=2.5.0"
+    "python-dateutil>=2.5.0",
+    "pymongo>=3.2.0",
 ]
 
 setup(
@@ -31,10 +32,9 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'pymongo': ['pymongo>=3.2.1'],
         'motor': ['motor>=1.1,<2.0'],
         'txmongo': ['txmongo>=16.0.1'],
-        'mongomock': ['mongomock', 'pymongo']  # pymongo needed for bson module
+        'mongomock': ['mongomock'],
     },
     license="MIT",
     zip_safe=False,

--- a/tests/common.py
+++ b/tests/common.py
@@ -78,11 +78,3 @@ class BaseDBTest:
 
     def setup(self):
         con.drop_database(TEST_DB)
-
-
-def get_pymongo_version():
-    version = getattr(pymongo, '__version__', None) or getattr(pymongo, 'version')
-    version = [int(i) for i in version.split('.')]
-    if len(version) == 2:
-        version.append(0)
-    return version

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -2,22 +2,16 @@ import pytest
 from datetime import datetime
 from bson import ObjectId
 from pymongo import MongoClient
+from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
 
-from ..common import BaseDBTest, get_pymongo_version, TEST_DB
+from ..common import BaseDBTest, TEST_DB
 
 from umongo import Document, EmbeddedDocument, fields, exceptions, Reference
+from umongo.frameworks import pymongo as framework_pymongo
 
 
-# Check if the required dependancies are met to run this driver's tests
-major, minor, _ = get_pymongo_version()
-if int(major) != 3 or int(minor) < 2:
-    dep_error = "pymongo driver requires pymongo>=3.2.0"
-else:
-    dep_error = None
-    from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
-
-if not dep_error:  # Make sure the module is valid by importing it
-    from umongo.frameworks import pymongo as framework_pymongo
+# All dependencies here are mandatory
+dep_error = None
 
 
 def _stripped(indexes):
@@ -41,7 +35,6 @@ def db():
     return make_db()
 
 
-@pytest.mark.skipif(dep_error is not None, reason=dep_error)
 class TestPymongo(BaseDBTest):
 
     def test_create(self, classroom_model):

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -3,22 +3,19 @@ from datetime import datetime
 from bson import ObjectId
 from functools import wraps
 
-from ..common import BaseDBTest, get_pymongo_version, TEST_DB, con
+from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
+
+from ..common import BaseDBTest, TEST_DB, con
 
 
-# Check if the required dependancies are met to run this driver's tests
+# Check if the required dependencies are met to run this driver's tests
 dep_error = None
 try:
     import pytest_twisted as _
     from txmongo import MongoConnection
-    major, minor, _ = get_pymongo_version()
-    if major != 3 or minor < 2:
-        dep_error = "txmongo driver requires pymongo>=3.2.0"
-    else:
-        from pymongo.results import InsertOneResult, UpdateResult, DeleteResult
     from twisted.internet.defer import Deferred, inlineCallbacks, succeed
 except ImportError:
-    dep_error = 'Missing txmongo module or pytest_twisted'
+    dep_error = 'Missing txmongo or pytest_twisted'
 
     # Given the test function are generator, we must wrap them into a dummy
     # function that pytest can skip

--- a/tox.ini
+++ b/tox.ini
@@ -10,7 +10,6 @@ deps =
     pytest>=2.8
     pytest-cov
     motor: motor>=1.0,<2.0
-    pymongo: pymongo>=3.2.1
     pymongo: mongomock>=3.5.0
     txmongo: txmongo>=16.0.1
     txmongo: pytest_twisted>=1.8


### PR DESCRIPTION
pymongo should be a hard dependency because bson is imported in the main code.

Also, there is no need to test the version is > 3.2 if 3.2 is required.