### PR TITLE
Fix __getattr__ to deepcopy Document and EmbeddedDocument

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst', 'rb') as history_file:
     history = history_file.read().decode('utf8')
 
 requirements = [
-    "marshmallow>=2.6.0",
+    "marshmallow>=2.18.0",
     "python-dateutil>=2.5.0",
     "pymongo>=3.7.0",
 ]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 from datetime import datetime
 from bson import ObjectId, DBRef
@@ -354,6 +356,26 @@ class TestDocument(BaseTest):
 
         with pytest.raises(NotImplementedError):
             Doc()
+
+    def test_deepcopy(self):
+
+        @self.instance.register
+        class Child(EmbeddedDocument):
+            name = fields.StrField()
+
+        @self.instance.register
+        class Parent(Document):
+            name = fields.StrField()
+            child = fields.EmbeddedField(Child)
+
+        john = Parent(name='John Doe', child={'name': 'John Doe Jr.'})
+        jane = copy(john)
+        assert jane.name == john.name
+        assert jane.child is john.child
+        jane = deepcopy(john)
+        assert jane.name == john.name
+        assert jane.child == john.child
+        assert jane.child is not john.child
 
 
 class TestConfig(BaseTest):

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 from marshmallow import ValidationError, missing
 
@@ -396,3 +398,23 @@ class TestEmbeddedDocument(BaseTest):
         with pytest.raises(exceptions.ValidationError) as exc:
             NonStrictEmbeddedDoc(a=42, b='foo')
         assert exc.value.messages == {'_schema': ['Unknown field name b.']}
+
+    def test_deepcopy(self):
+
+        @self.instance.register
+        class Child(EmbeddedDocument):
+            name = fields.StrField()
+
+        @self.instance.register
+        class Parent(EmbeddedDocument):
+            name = fields.StrField()
+            child = fields.EmbeddedField(Child)
+
+        john = Parent(name='John Doe', child={'name': 'John Doe Jr.'})
+        jane = copy(john)
+        assert jane.name == john.name
+        assert jane.child is john.child
+        jane = deepcopy(john)
+        assert jane.name == john.name
+        assert jane.child == john.child
+        assert jane.child is not john.child

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -281,6 +281,8 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
             self._data.set(name, value, to_raise=AttributeError)
 
     def __getattr__(self, name):
+        if name[:2] == name[-2:] == '__':
+            raise AttributeError(name)
         value = self._data.get(name, to_raise=AttributeError)
         return value if value is not missing else None
 

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -180,6 +180,8 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
             self._data.set(name, value, to_raise=AttributeError)
 
     def __getattr__(self, name):
+        if name[:2] == name[-2:] == '__':
+            raise AttributeError(name)
         value = self._data.get(name, to_raise=AttributeError)
         return value if value is not missing else None
 


### PR DESCRIPTION
I think the root cause is that when using `deepcopy` (I think this applies to pickle as well but didn't double-check), `hasattr(my_doc, __setstate__)` is called before the object is instantiated and therefore `self._data` does not exist, so we get an infinite recursion in `__getattr__`.

I think it is advised to add a condition like the one in this PR to fix this (inspired by https://stackoverflow.com/a/42272450/4653485).

Note that this prevents the use of attributes with leading and trailing double underscore, but oh well... I'm not sure this should even be considered a breaking change.

(CI errors unrelated and fixed in https://github.com/Scille/umongo/pull/155.)