### PR TITLE
Add clone method to Document

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ with open('HISTORY.rst', 'rb') as history_file:
     history = history_file.read().decode('utf8')
 
 requirements = [
-    "marshmallow>=2.6.0",
+    "marshmallow>=2.18.0",
     "python-dateutil>=2.5.0",
     "pymongo>=3.7.0",
 ]

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -377,6 +377,46 @@ class TestDocument(BaseTest):
         assert jane.child == john.child
         assert jane.child is not john.child
 
+    def test_clone(self):
+
+        @self.instance.register
+        class Child(EmbeddedDocument):
+            name = fields.StrField()
+
+        @self.instance.register
+        class Parent(Document):
+            name = fields.StrField()
+            birthday = fields.DateTimeField(dump_only=True)
+            child = fields.EmbeddedField(Child)
+
+        john = Parent(name='John Doe', child={'name': 'John Jr.'})
+        john.birthday = datetime(1995, 12, 12)
+        john.id = ObjectId("5672d47b1d41c88dcd37ef05")
+        jane = john.clone()
+        assert isinstance(jane, Parent)
+        assert isinstance(jane.child, Child)
+        assert jane.id is None
+        assert jane.birthday == datetime(1995, 12, 12)
+        assert jane.name == 'John Doe'
+        assert jane.child == john.child
+        assert jane.child is not john.child
+
+    def test_clone_default_id(self):
+        """Check clone gets a new default id if defaut is provided"""
+
+        @self.instance.register
+        class Parent(Document):
+            id = fields.ObjectIdField(attribute='_id', missing=ObjectId)
+            name = fields.StrField()
+
+        john = Parent(name='John Doe')
+        jane = john.clone()
+        assert isinstance(jane, Parent)
+        assert isinstance(john.id, ObjectId)
+        assert isinstance(jane.id, ObjectId)
+        assert jane.id != john.id
+        assert jane.name == 'John Doe'
+
 
 class TestConfig(BaseTest):
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 from datetime import datetime
 from bson import ObjectId, DBRef
@@ -354,6 +356,26 @@ class TestDocument(BaseTest):
 
         with pytest.raises(NotImplementedError):
             Doc()
+
+    def test_deepcopy(self):
+
+        @self.instance.register
+        class Child(EmbeddedDocument):
+            name = fields.StrField()
+
+        @self.instance.register
+        class Parent(Document):
+            name = fields.StrField()
+            child = fields.EmbeddedField(Child)
+
+        john = Parent(name='John Doe', child={'name': 'John Doe Jr.'})
+        jane = copy(john)
+        assert jane.name == john.name
+        assert jane.child is john.child
+        jane = deepcopy(john)
+        assert jane.name == john.name
+        assert jane.child == john.child
+        assert jane.child is not john.child
 
 
 class TestConfig(BaseTest):

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -1,3 +1,5 @@
+from copy import copy, deepcopy
+
 import pytest
 from marshmallow import ValidationError, missing
 
@@ -396,3 +398,23 @@ class TestEmbeddedDocument(BaseTest):
         with pytest.raises(exceptions.ValidationError) as exc:
             NonStrictEmbeddedDoc(a=42, b='foo')
         assert exc.value.messages == {'_schema': ['Unknown field name b.']}
+
+    def test_deepcopy(self):
+
+        @self.instance.register
+        class Child(EmbeddedDocument):
+            name = fields.StrField()
+
+        @self.instance.register
+        class Parent(EmbeddedDocument):
+            name = fields.StrField()
+            child = fields.EmbeddedField(Child)
+
+        john = Parent(name='John Doe', child={'name': 'John Doe Jr.'})
+        jane = copy(john)
+        assert jane.name == john.name
+        assert jane.child is john.child
+        jane = deepcopy(john)
+        assert jane.name == john.name
+        assert jane.child == john.child
+        assert jane.child is not john.child

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -1,3 +1,5 @@
+from copy import deepcopy
+
 from bson import DBRef
 
 from marshmallow import pre_load, post_load, pre_dump, post_dump, validates_schema  # republishing
@@ -157,6 +159,15 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
         elif isinstance(other, Reference):
             return isinstance(self, other.document_cls) and self.pk == other.pk
         return NotImplemented
+
+    def clone(self):
+        new = self.__class__()
+        data = deepcopy(self._data._data)
+        # Replace ID with new ID ("missing" unless a default value is provided)
+        data['_id'] = new._data._data['_id']
+        new._data._data = data
+        new._data._modified_data = set(data.keys())
+        return new
 
     @property
     def collection(self):

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -281,6 +281,8 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
             self._data.set(name, value, to_raise=AttributeError)
 
     def __getattr__(self, name):
+        if name[:2] == name[-2:] == '__':
+            raise AttributeError(name)
         value = self._data.get(name, to_raise=AttributeError)
         return value if value is not missing else None
 

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -180,6 +180,8 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
             self._data.set(name, value, to_raise=AttributeError)
 
     def __getattr__(self, name):
+        if name[:2] == name[-2:] == '__':
+            raise AttributeError(name)
         value = self._data.get(name, to_raise=AttributeError)
         return value if value is not missing else None
 


### PR DESCRIPTION
Implements `clone` method proposed in https://github.com/Scille/umongo/issues/83#issuecomment-268842201.

This PR is based on https://github.com/Scille/umongo/pull/157 which fixes DataProxy deepcopy.