### PR TITLE
Add Schema cache to as_marshmallow_schema

### DIFF
--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -133,6 +133,35 @@ class TestMarshmallow(BaseTest):
         assert ma_custom_base_schema.Meta.exclude == ('content',)
         assert ma_custom_base_schema.Meta.dump_only == ('id',)
 
+    def test_as_marshmallow_schema_cache(self):
+        ma_schema_cls = self.User.schema.as_marshmallow_schema()
+
+        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
+            params={'name': {'load_only': True}})
+        assert new_ma_schema_cls != ma_schema_cls
+
+        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
+            meta={'exclude': ('name',)})
+        assert new_ma_schema_cls != ma_schema_cls
+
+        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
+            check_unknown_fields=False)
+        assert new_ma_schema_cls != ma_schema_cls
+
+        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
+            mongo_world=True)
+        assert new_ma_schema_cls != ma_schema_cls
+
+        class MyBaseSchema(marshmallow.Schema):
+            pass
+
+        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
+            base_schema_cls=MyBaseSchema)
+        assert new_ma_schema_cls != ma_schema_cls
+
+        new_ma_schema_cls = self.User.schema.as_marshmallow_schema()
+        assert new_ma_schema_cls == ma_schema_cls
+
     def test_keep_attributes(self):
         @self.instance.register
         class Vehicle(Document):


### PR DESCRIPTION
This adds a cache to as_marshmallow_schema.

My use case is the following:

My app calls `as_marshmallow_schema` on all top-level schemas (one schema per resource). Some low-level schemas are used in many places throughout the code, embedded, sometimes deeply, in top-level schemas.

Without this change, the marshmallow schemas generated for those embedded umongo schemas are duplicated. Functionally, it makes no difference, but then they also get duplicated in the auto-generated OpenAPI specification that I generate with apispec, which makes the doc a bit ugly.

This is just one use case, but more generally, it's a pity to duplicate stuff.

The caching mechanism here is two-fold. Hashable parameters are used as a key in the cache dictionary. Dictionary parameters are not hashable, so they can't be used as key in the cache dict. They are stored as is and compared manually. Comparing all parameters manually would save one or two lines of code but would be much less efficient.

@touilleMan if that's fine for you, I'd like to release a new version (1.2.0) with this and #162. If you want to review but don't have time right now, please tell me, I can put this on hold.