### PR TITLE
Rework ListField and DictField

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -17,6 +17,8 @@ dev
   non-prefixed counterpart.
 * ``DictField`` and ``ListField`` don't default to empty ``Dict``/``List`` (see #105).
 * Serialize empty ``Dict``/``List`` as empty rather than missing (see #105).
+* Fix passing a default value to a ``DictField``/``ListField`` as a raw Python
+  ``dict``/``list`` (see #78).
 
 1.2.0 (2019-02-08)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -16,6 +16,7 @@ dev
   umongo field are passed to the pure marshmallow field and override their
   non-prefixed counterpart.
 * ``DictField`` and ``ListField`` don't default to empty ``Dict``/``List`` (see #105).
+* Serialize empty ``Dict``/``List`` as empty rather than missing (see #105).
 
 1.2.0 (2019-02-08)
 ------------------

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -15,6 +15,7 @@ dev
   from umongo's ``default``. Parameters prefixed with ``marshmallow_`` in the
   umongo field are passed to the pure marshmallow field and override their
   non-prefixed counterpart.
+* ``DictField`` and ``ListField`` don't default to empty ``Dict``/``List`` (see #105).
 
 1.2.0 (2019-02-08)
 ------------------

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -228,6 +228,8 @@ class TestMotorAsyncio(BaseDBTest):
             yield from teacher.commit()
             course = classroom_model.Course(name='Hoverboard 101', teacher=teacher)
             yield from course.commit()
+            assert student.courses is None
+            student.courses = []
             assert student.courses == []
             student.courses.append(course)
             yield from student.commit()

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -154,6 +154,8 @@ class TestPymongo(BaseDBTest):
         teacher.commit()
         course = classroom_model.Course(name='Hoverboard 101', teacher=teacher)
         course.commit()
+        assert student.courses is None
+        student.courses = []
         assert student.courses == []
         student.courses.append(course)
         student.commit()

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -192,6 +192,8 @@ class TestTxMongo(BaseDBTest):
         yield teacher.commit()
         course = classroom_model.Course(name='Hoverboard 101', teacher=teacher)
         yield course.commit()
+        assert student.courses is None
+        student.courses = []
         assert student.courses == []
         student.courses.append(course)
         yield student.commit()

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -241,8 +241,10 @@ class TestFields(BaseTest):
         d2 = MyDataProxy({'dict': {'a': 1, 'b': {'c': True}}})
         assert d2.to_mongo() == {'in_mongo_dict': {'a': 1, 'b': {'c': True}}}
 
-        # Empty dict is considered as missing field
         d2.set('dict', {})
+        assert d2.to_mongo() == {'in_mongo_dict': {}}
+        assert d2.to_mongo(update=True) == {'$set': {'in_mongo_dict': {}}}
+        d2.delete('dict')
         assert d2.to_mongo() == {}
         assert d2.to_mongo(update=True) == {'$unset': {'in_mongo_dict': ''}}
 
@@ -294,6 +296,10 @@ class TestFields(BaseTest):
         d.clear_modified()
         d.get('list').clear()
         assert d.dump() == {'list': []}
+        assert d.to_mongo() == {'in_mongo_list': []}
+        assert d.to_mongo(update=True) == {'$set': {'in_mongo_list': []}}
+        d.delete('list')
+        assert d.to_mongo() == {}
         assert d.to_mongo(update=True) == {'$unset': {'in_mongo_list': ''}}
 
         d.set('list', [1, 2, 3])

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -9,7 +9,7 @@ from uuid import UUID
 
 from umongo.data_proxy import data_proxy_factory
 from umongo import Document, EmbeddedDocument, Schema, EmbeddedSchema, fields, Reference
-from umongo.data_objects import List
+from umongo.data_objects import List, Dict
 
 from .common import BaseTest
 
@@ -267,6 +267,33 @@ class TestFields(BaseTest):
         d4.from_mongo({'in_mongo_dict': None})
         assert d4.get('dict') is None
 
+    def test_dict_default(self):
+
+        class MySchema(Schema):
+            # Passing a mutable as default is a bad idea in real life
+            d_dict = fields.DictField(default={'1': 1, '2': 2})
+            c_dict = fields.DictField(default=lambda: {'1': 1, '2': 2})
+
+        MyDataProxy = data_proxy_factory('My', MySchema())
+        d = MyDataProxy()
+        assert d.to_mongo() == {
+            'd_dict': {'1': 1, '2': 2},
+            'c_dict': {'1': 1, '2': 2},
+        }
+        assert isinstance(d.get('d_dict'), Dict)
+        assert isinstance(d.get('c_dict'), Dict)
+        d.get('d_dict')['3'] = 3
+        d.get('c_dict')['3'] = 3
+
+        d.delete('d_dict')
+        d.delete('c_dict')
+        assert d.to_mongo() == {
+            'd_dict': {'1': 1, '2': 2},
+            'c_dict': {'1': 1, '2': 2},
+        }
+        assert isinstance(d.get('d_dict'), Dict)
+        assert isinstance(d.get('c_dict'), Dict)
+
     def test_list(self):
 
         class MySchema(Schema):
@@ -352,7 +379,37 @@ class TestFields(BaseTest):
             d3._data.get('in_mongo_list')
         ) == '<object umongo.data_objects.List([])>'
 
-    def test_complexe_list(self):
+    def test_list_default(self):
+
+        class MySchema(Schema):
+            d_list = fields.ListField(fields.IntField(), default=(1, 2, 3))
+            c_list = fields.ListField(fields.IntField(), default=lambda: (1, 2, 3))
+
+        MyDataProxy = data_proxy_factory('My', MySchema())
+        d = MyDataProxy()
+        assert d.to_mongo() == {
+            'd_list': [1, 2, 3],
+            'c_list': [1, 2, 3],
+        }
+        assert isinstance(d.get('d_list'), List)
+        assert isinstance(d.get('c_list'), List)
+        d.get('d_list').append(4)
+        d.get('c_list').append(4)
+        assert d.to_mongo(update=True) == {
+            '$set': {'c_list': [1, 2, 3, 4], 'd_list': [1, 2, 3, 4]}}
+
+        d.delete('d_list')
+        d.delete('c_list')
+        assert d.to_mongo() == {
+            'd_list': [1, 2, 3],
+            'c_list': [1, 2, 3],
+        }
+        assert isinstance(d.get('d_list'), List)
+        assert isinstance(d.get('c_list'), List)
+        assert d.to_mongo(update=True) == {
+            '$set': {'c_list': [1, 2, 3], 'd_list': [1, 2, 3]}}
+
+    def test_complex_list(self):
 
         @self.instance.register
         class MyEmbeddedDocument(EmbeddedDocument):

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -4,12 +4,12 @@ from bson import ObjectId, DBRef, Decimal128
 import pytest
 from datetime import datetime
 from dateutil.tz.tz import tzutc, tzoffset
-from marshmallow import ValidationError
+from marshmallow import ValidationError, missing
 from uuid import UUID
 
 from umongo.data_proxy import data_proxy_factory
 from umongo import Document, EmbeddedDocument, Schema, EmbeddedSchema, fields, Reference
-from umongo.data_objects import List, Dict
+from umongo.data_objects import List
 
 from .common import BaseTest
 
@@ -248,17 +248,17 @@ class TestFields(BaseTest):
 
         d3 = MyDataProxy()
         d3.from_mongo({})
-        assert isinstance(d3.get('dict'), Dict)
+        assert d3.get('dict') is missing
         assert d3.to_mongo() == {}
         assert d3.to_mongo(update=True) is None
+
+        d3.from_mongo({'in_mongo_dict': {}})
+        assert d3._data.get('in_mongo_dict') == {}
         d3.get('dict')['field'] = 'value'
         assert d3.to_mongo(update=True) is None
         d3.get('dict').set_modified()
         assert d3.to_mongo(update=True) == {'$set': {'in_mongo_dict': {'field': 'value'}}}
         assert d3.to_mongo() == {'in_mongo_dict': {'field': 'value'}}
-
-        d3.from_mongo({'in_mongo_dict': {}})
-        assert d3._data.get('in_mongo_dict') == {}
 
         d4 = MyDataProxy({'dict': None})
         assert d4.to_mongo() == {'in_mongo_dict': None}
@@ -324,8 +324,10 @@ class TestFields(BaseTest):
 
         d2 = MyDataProxy()
         d2.from_mongo({})
-        assert isinstance(d2.get('list'), List)
+        assert d2.get('list') is missing
         assert d2.to_mongo() == {}
+        
+        d2.from_mongo({'in_mongo_list': []})
         d2.get('list').append(1)
         assert d2.to_mongo() == {'in_mongo_list': [1]}
         assert d2.to_mongo(update=True) == {'$set': {'in_mongo_list': [1]}}

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -53,10 +53,6 @@ __all__ = (
 
 class DictField(BaseField, ma_fields.Dict):
 
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default', Dict)
-        super().__init__(*args, **kwargs)
-
     def _deserialize(self, value, attr, data):
         value = super()._deserialize(value, attr, data)
         return Dict(value)
@@ -79,10 +75,6 @@ class DictField(BaseField, ma_fields.Dict):
 
 
 class ListField(BaseField, ma_fields.List):
-
-    def __init__(self, *args, **kwargs):
-        kwargs.setdefault('default', lambda: List(self.container))
-        super().__init__(*args, **kwargs)
 
     def _deserialize(self, value, attr, data):
         return List(self.container, super()._deserialize(value, attr, data))

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -58,7 +58,7 @@ class DictField(BaseField, ma_fields.Dict):
         return Dict(value)
 
     def _serialize_to_mongo(self, obj):
-        if not obj:
+        if obj is None:
             return missing
         return dict(obj)
 
@@ -80,7 +80,7 @@ class ListField(BaseField, ma_fields.List):
         return List(self.container, super()._deserialize(value, attr, data))
 
     def _serialize_to_mongo(self, obj):
-        if not obj:
+        if obj is None:
             return missing
         return [self.container.serialize_to_mongo(each) for each in obj]
 


### PR DESCRIPTION
Closes #105.
Fixes #78.

-  ``DictField`` and ``ListField`` don't default to empty ``Dict``/``List`` (see #105).
-  Serialize empty ``Dict``/``List`` as empty rather than missing (see #105).
-  Fix passing a default value to a ``DictField``/``ListField`` as a raw Python
  ``dict``/``list`` (see #78).