### PR TITLE
Raise AlreadyCreatedError when modifying pk on a created document

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -417,6 +417,19 @@ class TestDocument(BaseTest):
         assert jane.id != john.id
         assert jane.name == 'John Doe'
 
+    def test_modify_pk_field(self):
+
+        @self.instance.register
+        class User(Document):
+            primary_key = fields.ObjectIdField(attribute='_id', default=ObjectId)
+            name = fields.StrField()
+
+        john = User(name='John Doc')
+        john.primary_key = ObjectId()
+        john.is_created = True
+        with pytest.raises(exceptions.AlreadyCreatedError):
+            john.primary_key = ObjectId()
+
 
 class TestConfig(BaseTest):
 

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -1,7 +1,7 @@
 from marshmallow import ValidationError, missing
 
 from .abstract import BaseDataObject
-from .exceptions import FieldNotLoadedError, UnknownFieldInDBError
+from .exceptions import AlreadyCreatedError, FieldNotLoadedError, UnknownFieldInDBError
 from .i18n import gettext as _
 
 
@@ -144,8 +144,12 @@ class BaseDataProxy:
         name, _ = self._get_field(name, to_raise)
         return self._data[name]
 
-    def set(self, name, value, to_raise=KeyError):
+    def set(self, name, value, to_raise=KeyError, is_created=False):
         name, field = self._get_field(name, to_raise)
+        if name == '_id' and is_created:
+            raise AlreadyCreatedError(
+                "The private key of a document can't be changed "
+                "if it is already created in database")
         if value is None and not getattr(field, 'allow_none', False):
             raise ValidationError(field.error_messages['null'])
         if value is not None:

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -282,7 +282,7 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
         self._data.delete(name)
 
     def __setitem__(self, name, value):
-        self._data.set(name, value)
+        self._data.set(name, value, is_created=self.is_created)
 
     def __setattr__(self, name, value):
         # Try to retrieve name among class's attributes and __slots__
@@ -293,7 +293,7 @@ class DocumentImplementation(BaseDataObject, Implementation, metaclass=MetaDocum
         if name in self.__real_attributes:
             object.__setattr__(self, name, value)
         else:
-            self._data.set(name, value, to_raise=AttributeError)
+            self._data.set(name, value, to_raise=AttributeError, is_created=self.is_created)
 
     def __getattr__(self, name):
         if name[:2] == name[-2:] == '__':

--- a/umongo/exceptions.py
+++ b/umongo/exceptions.py
@@ -49,6 +49,10 @@ class NotCreatedError(UMongoError):
     pass
 
 
+class AlreadyCreatedError(UMongoError):
+    pass
+
+
 class NoCollectionDefinedError(UMongoError):
     pass
 


### PR DESCRIPTION
Closes #83.

This change ensures an Exception is raised when modifying a document id after it is created.

I'm not really happy with this implementation. I don't think the initial issue is worth this change.

Feedback welcome. Better implementation even more welcome...

Also, the error message could be improved to suggest using `clone` (see #83).