### PR TITLE
Round datetimes to milliseconds in LocalDateTimeField

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -150,6 +150,7 @@ class TestFields(BaseTest):
 
         class MySchema(EmbeddedSchema):
             a = fields.DateTimeField()
+            b = fields.LocalDateTimeField()
 
         s = MySchema(strict=True)
         data, _ = s.load({'a': datetime(2016, 8, 6)})
@@ -161,10 +162,14 @@ class TestFields(BaseTest):
         with pytest.raises(ValidationError):
             s.load({'a': "dummy"})
 
-        # Test DateTimeField rounds to milliseconds
+        # Test DateTimeField and LocalDateTimeField round to milliseconds
         s = MySchema()
-        data, _ = s.load({'a': datetime(2016, 8, 6, 12, 30, 30, 123456)})
+        data, _ = s.load({
+            'a': datetime(2016, 8, 6, 12, 30, 30, 123456),
+            'b': datetime(2016, 8, 6, 12, 30, 30, 123456),
+        })
         assert data['a'].microsecond == 123000
+        assert data['b'].microsecond == 123000
 
     def test_strictdatetime(self):
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -181,8 +181,12 @@ class LocalDateTimeField(BaseField, ma_fields.LocalDateTime):
 
     def _deserialize(self, value, attr, data):
         if isinstance(value, datetime):
-            return value
-        return super()._deserialize(value, attr, data)
+            ret = value
+        else:
+            ret = super()._deserialize(value, attr, data)
+        # MongoDB stores datetimes with a millisecond precision.
+        # Don't keep more precision in the object than in the database.
+        return ret.replace(microsecond=round(ret.microsecond, -3))
 
 
 # class TimeField(BaseField, ma_fields.Time):


### PR DESCRIPTION
Forgotten in https://github.com/Scille/umongo/pull/172.