### PR TITLE
Simplify "partial" in pymongo._io_validate_data_proxy

### DIFF
--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -244,7 +244,7 @@ def _run_validators(validators, field, value):
 def _io_validate_data_proxy(schema, data_proxy, partial=None):
     errors = {}
     for name, field in schema.fields.items():
-        if partial and (partial is True or name not in partial):
+        if partial and name not in partial:
             continue
         data_name = field.attribute or name
         value = data_proxy._data[data_name]


### PR DESCRIPTION
`partial` can't be `True`, it is `None` or an iterable.

This is consistent with what is done for txmongo and motor_asyncio.