### PR TITLE
Issue warning when map_entry can't find field for query

### DIFF
--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -739,7 +739,8 @@ class TestMotorAsyncio(BaseDBTest):
             assert (await InheritanceSearchChild1Child.find().count()) == 1
             assert (await InheritanceSearchChild2.find().count()) == 1
 
-            res = await InheritanceSearchParent.find_one({'sc1f': 1})
+            with pytest.warns(RuntimeWarning):
+                res = await InheritanceSearchParent.find_one({'sc1f': 1})
             assert isinstance(res, InheritanceSearchChild1Child)
 
             cursor = InheritanceSearchParent.find({'pf': 1})

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -586,7 +586,8 @@ class TestPymongo(BaseDBTest):
         assert InheritanceSearchChild1Child.count_documents() == 1
         assert InheritanceSearchChild2.count_documents() == 1
 
-        res = InheritanceSearchParent.find_one({'sc1f': 1})
+        with pytest.warns(RuntimeWarning):
+            res = InheritanceSearchParent.find_one({'sc1f': 1})
         assert isinstance(res, InheritanceSearchChild1Child)
 
         res = InheritanceSearchParent.find({'pf': 1})

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -687,7 +687,8 @@ class TestTxMongo(BaseDBTest):
         res = yield InheritanceSearchChild2.find()
         assert len(res) == 1
 
-        res = yield InheritanceSearchParent.find_one({'sc1f': 1})
+        with pytest.warns(RuntimeWarning):
+            res = yield InheritanceSearchParent.find_one({'sc1f': 1})
         assert isinstance(res, InheritanceSearchChild1Child)
 
         res = yield InheritanceSearchParent.find({'pf': 1})

--- a/umongo/query_mapper.py
+++ b/umongo/query_mapper.py
@@ -1,3 +1,5 @@
+import warnings
+
 from umongo.fields import ListField, EmbeddedField
 
 
@@ -17,6 +19,11 @@ def map_entry(entry, fields):
         fields = field.container.embedded_document_cls.schema.fields
     elif isinstance(field, EmbeddedField):
         fields = field.embedded_document_cls.schema.fields
+    elif field is None and not entry.startswith('$'):
+        warnings.warn(
+            "Query mapper can't find field for this query. Field name won't be mapped.",
+            RuntimeWarning,
+        )
     return getattr(field, 'attribute', None) or entry, fields
 
 


### PR DESCRIPTION
While working on `map_query`, I realized a shortcoming of the field/name mapping in the inheritance case.

In the framework tests, we use the parent class to find a child element based on a query on a field that does not exist in the parent class.

```py
InheritanceSearchParent.find_one({'sc1f': 1})
```

It works, but I believe it is wrong. The query mapper does not have access to the field, so it can not do its job. In fact the query will fail if the field is an `EmbeddedField` (I could reproduce that) because in `map_entry` we won't pass in the dedicated case as `field` is `None`:

```py
elif isinstance(field, EmbeddedField):
```

I don't think we can pass the child classes fields here, and it would be a bad idea because different children could have different fields for the same name, so the field is undefined.

Since it works in some (in fact, most) cases anyway, I propose to just add a non-breaking warning at least for now. But I can make this an `Exception`. Or if we plan to forbid this in the next major version, I can use a `DeprecationWarning`.

Or do we want users to be able to pass query entries that don't match a field known to the model?

This is a corner case, but since the wrong use was shown in the tests, users may be relying on it.

I can review the warning/exception type, the message string (add a note about inheritance ?), and perhaps rework the framework tests to isolate this specific test.

Feedback welcome.