### PR TITLE
Add count_documents support to motor asyncio Documents

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,10 +29,10 @@ jobs:
 
     - { python: '3.7', env: TOXENV=lint }
     - { python: '3.5', env: TOXENV=py35-pymongo }
-    - { python: '3.5', env: TOXENV=py35-motor }
+    - { python: '3.5', env: TOXENV=py35-motor1 }
     - { python: '3.5', env: TOXENV=py35-txmongo }
     - { python: '3.7', env: TOXENV=py37-pymongo }
-    - { python: '3.7', env: TOXENV=py37-motor }
+    - { python: '3.7', env: TOXENV=py37-motor2 }
     - { python: '3.7', env: TOXENV=py37-txmongo }
 
     - stage: PyPI Release

--- a/setup.py
+++ b/setup.py
@@ -32,7 +32,7 @@ setup(
     include_package_data=True,
     install_requires=requirements,
     extras_require={
-        'motor': ['motor>=1.1,<2.0'],
+        'motor': ['motor>=1.1,<3.0'],
         'txmongo': ['txmongo>=16.0.1'],
         'mongomock': ['mongomock'],
     },

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -115,17 +115,17 @@ class TestMotorAsyncio(BaseDBTest):
             with pytest.raises(exceptions.NotCreatedError):
                 await john.remove()
             await john.commit()
-            assert (await Student.count()) == 1
+            assert (await Student.count_documents()) == 1
             ret = await john.remove()
             assert isinstance(ret, DeleteResult)
             assert not john.is_created
-            assert (await Student.count()) == 0
+            assert (await Student.count_documents()) == 0
             with pytest.raises(exceptions.NotCreatedError):
                 await john.remove()
             # Can re-commit the document in database
             await john.commit()
             assert john.is_created
-            assert (await Student.count()) == 1
+            assert (await Student.count_documents()) == 1
             # Test conditional delete
             with pytest.raises(exceptions.DeleteError):
                 await john.remove(conditions={'name': 'Bad Name'})
@@ -172,8 +172,8 @@ class TestMotorAsyncio(BaseDBTest):
                 count_with_limit_and_skip = await cursor.count(with_limit_and_skip=True)
                 assert count_with_limit_and_skip == 4
             else:
-                assert (await Student.count()) == 10
-                assert (await Student.count(limit=5, skip=6)) == 4
+                assert (await Student.count_documents()) == 10
+                assert (await Student.count_documents(limit=5, skip=6)) == 4
 
             # Make sure returned documents are wrapped
             names = []
@@ -741,10 +741,10 @@ class TestMotorAsyncio(BaseDBTest):
             await InheritanceSearchChild1Child(pf=1, sc1f=1).commit()
             await InheritanceSearchChild2(pf=2, c2f=2).commit()
 
-            assert (await InheritanceSearchParent.count()) == 4
-            assert (await InheritanceSearchChild1.count()) == 2
-            assert (await InheritanceSearchChild1Child.count()) == 1
-            assert (await InheritanceSearchChild2.count()) == 1
+            assert (await InheritanceSearchParent.count_documents()) == 4
+            assert (await InheritanceSearchChild1.count_documents()) == 2
+            assert (await InheritanceSearchChild1Child.count_documents()) == 1
+            assert (await InheritanceSearchChild2.count_documents()) == 1
 
             res = await InheritanceSearchParent.find_one({'sc1f': 1})
             assert isinstance(res, InheritanceSearchChild1Child)
@@ -814,13 +814,13 @@ class TestMotorAsyncio(BaseDBTest):
                 ]
             ).commit()
 
-            res = await Book.count({'title': 'The Hobbit'})
+            res = await Book.count_documents({'title': 'The Hobbit'})
             assert res == 1
-            res = await Book.count({'author.name': {'$in': ['JK Rowling', 'JRR Tolkien']}})
+            res = await Book.count_documents({'author.name': {'$in': ['JK Rowling', 'JRR Tolkien']}})
             assert res == 2
-            res = await Book.count({'$and': [{'chapters.name': 'Roast Mutton'}, {'title': 'The Hobbit'}]})
+            res = await Book.count_documents({'$and': [{'chapters.name': 'Roast Mutton'}, {'title': 'The Hobbit'}]})
             assert res == 1
-            res = await Book.count({'chapters.name': {'$all': ['Roast Mutton', 'A Short Rest']}})
+            res = await Book.count_documents({'chapters.name': {'$all': ['Roast Mutton', 'A Short Rest']}})
             assert res == 1
 
         loop.run_until_complete(do_test())

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -175,6 +175,11 @@ class TestMotorAsyncio(BaseDBTest):
                 assert (await Student.count_documents()) == 10
                 assert (await Student.count_documents(limit=5, skip=6)) == 4
 
+            # to_list with callback should fail
+            error = NotImplementedError if MOTOR_VERSION < (2, 0, 0) else TypeError
+            with pytest.raises(error):
+                await cursor.to_list(length=100, callback=lambda r, e: r if r else e)
+
             # Make sure returned documents are wrapped
             names = []
             for elem in (await cursor.to_list(length=100)):

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = lint,{py35,py36,py37}-{motor,pymongo,txmongo}
+envlist = lint,{py35,py36,py37}-{motor1,motor2,pymongo,txmongo}
 
 [testenv]
 setenv =
@@ -7,7 +7,8 @@ setenv =
 deps =
     pytest>=4.0.0
     pytest-cov>=2.6.0
-    motor: motor>=1.0,<2.0
+    motor1: motor>=1.0,<2.0
+    motor2: motor>=2.0,<3.0
     pymongo: mongomock>=3.5.0
     txmongo: txmongo>=16.0.1
     txmongo: pytest_twisted>=1.9

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -269,7 +269,7 @@ class MotorAsyncIODocument(DocumentImplementation):
         return WrappedCursor(cls, cls.collection.find(*args, filter=filter, **kwargs))
 
     @classmethod
-    async def count(cls, filter=None, *, with_limit_and_skip=False, **kwargs):
+    async def count_documents(cls, filter=None, *, with_limit_and_skip=False, **kwargs):
         """
         Return a count of the documents in a collection.
         """

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -48,19 +48,8 @@ class WrappedCursor(AsyncIOMotorCursor):
         return self.raw_cursor.each(wrapped_callback)
 
     def to_list(self, length, callback=None):
-        if MOTOR_VERSION < (2, 0):
-            raw_future = self.raw_cursor.to_list(length, callback=callback)
-        else:
-            raw_future = self.raw_cursor.to_list(length)
-
-            def callback_wrapper(future):
-                error = None
-                try:
-                    result = future.result()
-                except Exception as exc:
-                    error = exc
-                callback(result, error)
-            raw_future.add_done_callback(callback_wrapper)
+        kwargs = {"callback": callback} if callback else {}
+        raw_future = self.raw_cursor.to_list(length, **kwargs)
         cooked_future = asyncio.Future()
         builder = self.document_cls.build_from_mongo
 


### PR DESCRIPTION
Update API to support v2.0.0 of motor. This involves changing tests
that use the deprecated count() cursor method to use either
count_documents() or to_list() instead, and removing the callback
keyword argument from the to_list wrapper.