### PR TITLE
Don't call _deserialize_from_mongo in Field._deserialize

### DIFF
--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -212,8 +212,9 @@ class TestEmbeddedDocument(BaseTest):
         assert child.to_mongo() == {'in_mongo_a_child': 1, 'b': 2, 'c': 3, '_cls': 'EmbeddedChild'}
         assert grandchild.to_mongo() == {'d': 4, '_cls': 'GrandChild'}
 
-        with pytest.raises(ValidationError):
+        with pytest.raises(ValidationError) as exc:
             MyDoc(parent=OtherEmbedded())
+        assert exc.value.args[0] == {'parent': {'_schema': ['Invalid input type.']}}
         with pytest.raises(ValidationError):
             MyDoc(child=parent)
         doc = MyDoc(parent=child, child=child)

--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -595,12 +595,6 @@ class TestFields(BaseTest):
         d2.from_mongo({'in_mongo_ref': None})
         assert d2.get('ref') is None
 
-        # Test from_mongo behavior with already deserialized data
-        d3 = MyDataProxy()
-        d3.from_mongo({
-            'in_mongo_ref': Reference(MyReferencedDoc, ObjectId("5672d47b1d41c88dcd37ef05"))})
-        assert not isinstance(d3._data['in_mongo_ref'].pk, Reference)
-
     def test_reference_lazy(self):
 
         @self.instance.register
@@ -681,12 +675,6 @@ class TestFields(BaseTest):
         assert d2.to_mongo() == {'in_mongo_gref': None}
         d2.from_mongo({'in_mongo_gref': None})
         assert d2.get('gref') is None
-
-        # Test from_mongo behavior with already deserialized data
-        d3 = MyDataProxy()
-        d3.from_mongo({
-            'in_mongo_gref': Reference(ToRef1, ObjectId("5672d47b1d41c88dcd37ef05"))})
-        assert not isinstance(d3._data['in_mongo_gref'].pk, Reference)
 
     def test_decimal(self):
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -307,9 +307,7 @@ class ReferenceField(BaseField, ma_bonus_fields.Reference):
             raise ValidationError(_("`{document}` reference expected.").format(
                 document=self.document_cls.__name__))
         value = super()._deserialize(value, attr, data)
-        # `value` is similar to data received from the database so we
-        # can use `_deserialize_from_mongo` to finish the deserialization
-        return self._deserialize_from_mongo(value)
+        return self.reference_cls(self.document_cls, value)
 
     def _serialize_to_mongo(self, obj):
         return obj.pk

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -313,10 +313,6 @@ class ReferenceField(BaseField, ma_bonus_fields.Reference):
         return obj.pk
 
     def _deserialize_from_mongo(self, value):
-        # When this method is called from `_deserialize`, `value` can be
-        # already deserialized, in such a case do nothing.
-        if isinstance(value, self.reference_cls):
-            return value
         return self.reference_cls(self.document_cls, value)
 
     def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
@@ -377,10 +373,6 @@ class GenericReferenceField(BaseField, ma_bonus_fields.GenericReference):
         return {'_id': obj.pk, '_cls': obj.document_cls.__name__}
 
     def _deserialize_from_mongo(self, value):
-        # When this method is called from `_deserialize`, `value` can be
-        # already deserialized, in such a case do nothing.
-        if isinstance(value, self.reference_cls):
-            return value
         document_cls = self._document_cls(value['_cls'])
         return self.reference_cls(document_cls, value['_id'])
 


### PR DESCRIPTION
For the reason this was done in the first place, see https://github.com/Scille/umongo/pull/84#issuecomment-268840412.

I just stumbled on a use case where it wouldn't work.

The assumption that deserialization (from outside to OO world) provides what pymongo would return is incorrect when the data is not serialized in DB in its OO world form. This is the case for fields that have custom `_serialize_to_mongo` / `_deserialize_from_mongo` methods.

For instance, if the embedded document contains a `DateField`, the deserialization produces a `datetime.date` and `deserialize_from_mongo` will choke on that because it expects a `datetime.datetime`.

I believe this fix does the right thing.

The only thing that bothers me is that it duplicates the `_schema` string from marshmallow:

```py
    ValidationError({'_schema': ['Invalid input type.']})
```

but this is public API, so it's not a big deal. It won't change in a minor version.