### PR TITLE
Added link to documentation

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -16,6 +16,8 @@
     :target: https://coveralls.io/github/Scille/umongo?branch=master
     :alt: Code coverage
 
+https://umongo.readthedocs.io/en/latest/userguide.html
+
 μMongo is a Python MongoDB ODM. It inception comes from two needs:
 the lack of async ODM and the difficulty to do document (un)serialization
 with existing ODMs.


### PR DESCRIPTION
Took me awhile to find documentation because it wasn't linked on the GitHub README. I kept looking because I could see that the program was really well documented. Once I found it, I thought others might be having the same problem, so I propose to add the link.