### PR TITLE
Fix millisecond overflow when milliseconds round to 1s in DateTimeField

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -171,6 +171,19 @@ class TestFields(BaseTest):
         })
         assert data['a'].microsecond == 123000
         assert data['b'].microsecond == 123000
+        s = MySchema()
+        data, _ = s.load({
+            'a': dt.datetime(2016, 8, 6, 12, 59, 59, 999876),
+            'b': dt.datetime(2016, 8, 6, 12, 59, 59, 999876),
+        })
+        assert data['a'].hour == 13
+        assert data['b'].hour == 13
+        assert data['a'].minute == 0
+        assert data['b'].minute == 0
+        assert data['a'].second == 0
+        assert data['b'].second == 0
+        assert data['a'].microsecond == 0
+        assert data['b'].microsecond == 0
 
     def test_strictdatetime(self):
 

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -165,6 +165,18 @@ class FloatField(BaseField, ma_fields.Float):
     pass
 
 
+def _round_to_millisecond(datetime):
+    """Round a datetime to millisecond precision
+
+    MongoDB stores datetimes with a millisecond precision.
+    For consistency, use the same precision in the object representation.
+    """
+    microseconds = round(datetime.microsecond, -3)
+    if microseconds == 1000000:
+        return datetime.replace(microsecond=0) + dt.timedelta(seconds=1)
+    return datetime.replace(microsecond=microseconds)
+
+
 class DateTimeField(BaseField, ma_fields.DateTime):
 
     def _deserialize(self, value, attr, data):
@@ -172,9 +184,7 @@ class DateTimeField(BaseField, ma_fields.DateTime):
             ret = value
         else:
             ret = super()._deserialize(value, attr, data)
-        # MongoDB stores datetimes with a millisecond precision.
-        # Don't keep more precision in the object than in the database.
-        return ret.replace(microsecond=round(ret.microsecond, -3))
+        return _round_to_millisecond(ret)
 
 
 class LocalDateTimeField(BaseField, ma_fields.LocalDateTime):
@@ -184,9 +194,7 @@ class LocalDateTimeField(BaseField, ma_fields.LocalDateTime):
             ret = value
         else:
             ret = super()._deserialize(value, attr, data)
-        # MongoDB stores datetimes with a millisecond precision.
-        # Don't keep more precision in the object than in the database.
-        return ret.replace(microsecond=round(ret.microsecond, -3))
+        return _round_to_millisecond(ret)
 
 
 # class TimeField(BaseField, ma_fields.Time):


### PR DESCRIPTION
Fixes #189.

The second commit introduces an abstract class to factorize the logic. @touilleMan, if you like the first version better, I can remove the second commit.