### PR TITLE
Let Reference and GenericReference round-trip

### DIFF
--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -432,9 +432,15 @@ class TestMarshmallow(BaseTest):
         # schema to OO world
         ma_schema_cls = Doc.schema.as_marshmallow_schema()
         ma_schema = ma_schema_cls()
+        # Dump uMongo object
         ret = ma_schema.dump(doc)
         assert not ret.errors
         assert ret.data == serialized
+        # Dump OO data (not uMongo object) to ensure bonus fields round-trip
+        ret = ma_schema.dump(oo_data)
+        assert not ret.errors
+        assert ret.data == serialized
+        # Load serialized data
         ret = ma_schema.load(serialized)
         assert not ret.errors
         assert ret.data == oo_data

--- a/umongo/marshmallow_bonus.py
+++ b/umongo/marshmallow_bonus.py
@@ -149,6 +149,9 @@ class Reference(ObjectId):
             return str(value)
         else:
             # In OO world, value is a :class:`umongo.data_object.Reference`
+            # or an ObjectId before being loaded into a Document
+            if isinstance(value, bson.ObjectId):
+                return str(value)
             return str(value.pk)
 
 
@@ -169,6 +172,9 @@ class GenericReference(ma_fields.Field):
             return {'id': str(value['_id']), 'cls': value['_cls']}
         else:
             # In OO world, value is a :class:`umongo.data_object.Reference`
+            # or a dict before being loaded into a Document
+            if isinstance(value, dict):
+                return {'id': str(value['id']), 'cls': value['cls']}
             return {'id': str(value.pk), 'cls': value.document_cls.__name__}
 
     def _deserialize(self, value, attr, data):


### PR DESCRIPTION
Marshmallow bonus `Reference` field does not round-trip.

It works if the data is loaded then passed to a `Document` then the document is dumped.

```py
loaded_data = Schema().load(data)
loaded_data['ref']  # ObjectId
doc = Document(**loaded_data)
doc.ref  # Reference
dumped_data = Schema().dump(doc)
dumped_data  # string
```

But it fails if the data is never passed to a document init: the `Reference` field serialization method expects a `Reference` data object, not an `ObjectId`.

```py
data['ref']  # string
loaded_data = Schema().load(data)
loaded_data['ref']  # ObjectId
dumped_data = Schema().dump(loaded_data)  # fails
```

Same with `GenericReference` field.

This PR allows to load then dump references without instantiating an object.