### PR TITLE
Rework exceptions

### DIFF
--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -4,12 +4,16 @@ import pytest
 
 from bson import ObjectId
 
-from umongo import (Document, fields, AlreadyRegisteredDocumentError, EmbeddedDocument,
-                    NotRegisteredDocumentError, NoDBDefinedError)
+from umongo import Document, fields, EmbeddedDocument
 from umongo.instance import Instance
 from umongo.document import DocumentTemplate, DocumentImplementation
 from umongo.embedded_document import EmbeddedDocumentTemplate, EmbeddedDocumentImplementation
-from umongo.frameworks import MongoMockInstance, MotorAsyncIOInstance, TxMongoInstance, PyMongoInstance
+from umongo.frameworks import (
+    MongoMockInstance, MotorAsyncIOInstance, TxMongoInstance, PyMongoInstance
+)
+from umongo.exceptions import (
+    AlreadyRegisteredDocumentError, NotRegisteredDocumentError, NoDBDefinedError
+)
 
 from .common import MockedDB, MockedInstance
 

--- a/umongo/__init__.py
+++ b/umongo/__init__.py
@@ -21,11 +21,8 @@ from .exceptions import (
     NoDBDefinedError,
     NotRegisteredDocumentError,
     AlreadyRegisteredDocumentError,
-    BuilderNotDefinedError,
     UpdateError,
-    MissingSchemaError,
     NotCreatedError,
-    NoCollectionDefinedError,
     FieldNotLoadedError
 )
 from . import fields, validate
@@ -61,11 +58,8 @@ __all__ = (
     'NoDBDefinedError',
     'NotRegisteredDocumentError',
     'AlreadyRegisteredDocumentError',
-    'BuilderNotDefinedError',
     'UpdateError',
-    'MissingSchemaError',
     'NotCreatedError',
-    'NoCollectionDefinedError',
     'FieldNotLoadedError',
 
     'fields',

--- a/umongo/__init__.py
+++ b/umongo/__init__.py
@@ -18,12 +18,11 @@ from .document import (
 from .exceptions import (
     UMongoError,
     ValidationError,
-    NoDBDefinedError,
-    NotRegisteredDocumentError,
-    AlreadyRegisteredDocumentError,
     UpdateError,
+    DeleteError,
     NotCreatedError,
-    FieldNotLoadedError
+    FieldNotLoadedError,
+    UnknownFieldInDBError,
 )
 from . import fields, validate
 from .schema import BaseSchema, Schema, EmbeddedSchema
@@ -55,12 +54,11 @@ __all__ = (
 
     'UMongoError',
     'ValidationError',
-    'NoDBDefinedError',
-    'NotRegisteredDocumentError',
-    'AlreadyRegisteredDocumentError',
     'UpdateError',
+    'DeleteError',
     'NotCreatedError',
     'FieldNotLoadedError',
+    'UnknownFieldInDBError',
 
     'fields',
 

--- a/umongo/__init__.py
+++ b/umongo/__init__.py
@@ -22,6 +22,7 @@ from .exceptions import (
     DeleteError,
     NotCreatedError,
     FieldNotLoadedError,
+    NoneReferenceError,
     UnknownFieldInDBError,
 )
 from . import fields, validate
@@ -58,6 +59,7 @@ __all__ = (
     'DeleteError',
     'NotCreatedError',
     'FieldNotLoadedError',
+    'NoneReferenceError',
     'UnknownFieldInDBError',
 
     'fields',

--- a/umongo/exceptions.py
+++ b/umongo/exceptions.py
@@ -46,5 +46,9 @@ class FieldNotLoadedError(UMongoError):
     """Accessing a field not loaded after partial load"""
 
 
+class NoneReferenceError(UMongoError):
+    """Retrieving a None reference"""
+
+
 class UnknownFieldInDBError(UMongoError):
     """Data from database contains unknown field"""

--- a/umongo/exceptions.py
+++ b/umongo/exceptions.py
@@ -1,65 +1,50 @@
+"""umongo exceptions"""
 from marshmallow import ValidationError  # noqa, republishing
 
 
 class UMongoError(Exception):
-    pass
-
-
-# class ValidationError(ValidationError, UMongoError):
-#     pass
-
-
-class AbstractDocumentError(UMongoError):
-    pass
-
-
-class DocumentDefinitionError(UMongoError):
-    pass
-
-
-class NoDBDefinedError(UMongoError):
-    pass
-
-
-class NotRegisteredDocumentError(UMongoError):
-    pass
-
-
-class AlreadyRegisteredDocumentError(UMongoError):
-    pass
-
-
-class BuilderNotDefinedError(UMongoError):
-    pass
-
-
-class UpdateError(UMongoError):
-    pass
-
-
-class DeleteError(UMongoError):
-    pass
-
-
-class MissingSchemaError(UMongoError):
-    pass
-
-
-class NotCreatedError(UMongoError):
-    pass
-
-
-class NoCollectionDefinedError(UMongoError):
-    pass
-
-
-class FieldNotLoadedError(UMongoError):
-    pass
+    """Base umongo error"""
 
 
 class NoCompatibleBuilderError(UMongoError):
-    pass
+    """Can't find builder compatible with database"""
+
+
+class AbstractDocumentError(UMongoError):
+    """Raised when instantiating an abstract document"""
+
+
+class DocumentDefinitionError(UMongoError):
+    """Error in document definition"""
+
+
+class NoDBDefinedError(UMongoError):
+    """No database defined"""
+
+
+class NotRegisteredDocumentError(UMongoError):
+    """Document not registered"""
+
+
+class AlreadyRegisteredDocumentError(UMongoError):
+    """Document already registerd"""
+
+
+class UpdateError(UMongoError):
+    """Error while updating document"""
+
+
+class DeleteError(UMongoError):
+    """Error while deleting document"""
+
+
+class NotCreatedError(UMongoError):
+    """Document does not exist in database"""
+
+
+class FieldNotLoadedError(UMongoError):
+    """Accessing a field not loaded after partial load"""
 
 
 class UnknownFieldInDBError(UMongoError):
-    pass
+    """Data from database contains unknown field"""

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -9,7 +9,9 @@ from ..builder import BaseBuilder
 from ..document import DocumentImplementation
 from ..data_proxy import missing
 from ..data_objects import Reference
-from ..exceptions import NotCreatedError, UpdateError, ValidationError, DeleteError
+from ..exceptions import (
+    NotCreatedError, UpdateError, DeleteError, ValidationError, NoneReferenceError
+)
 from ..fields import ReferenceField, ListField, EmbeddedField
 from ..query_mapper import map_query
 
@@ -356,7 +358,7 @@ class MotorAsyncIOReference(Reference):
     async def fetch(self, no_data=False, force_reload=False):
         if not self._document or force_reload:
             if self.pk is None:
-                raise ReferenceError('Cannot retrieve a None Reference')
+                raise NoneReferenceError('Cannot retrieve a None Reference')
             self._document = await self.document_cls.find_one(self.pk)
             if not self._document:
                 raise ValidationError(self.error_messages['not_found'].format(

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -6,7 +6,9 @@ from ..builder import BaseBuilder
 from ..document import DocumentImplementation
 from ..data_proxy import missing
 from ..data_objects import Reference
-from ..exceptions import NotCreatedError, UpdateError, DeleteError, ValidationError
+from ..exceptions import (
+    NotCreatedError, UpdateError, DeleteError, ValidationError, NoneReferenceError
+)
 from ..fields import ReferenceField, ListField, EmbeddedField
 from ..query_mapper import map_query
 
@@ -291,7 +293,7 @@ class PyMongoReference(Reference):
     def fetch(self, no_data=False, force_reload=False):
         if not self._document or force_reload:
             if self.pk is None:
-                raise ReferenceError('Cannot retrieve a None Reference')
+                raise NoneReferenceError('Cannot retrieve a None Reference')
             self._document = self.document_cls.find_one(self.pk)
             if not self._document:
                 raise ValidationError(self.error_messages['not_found'].format(

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -8,7 +8,9 @@ from ..builder import BaseBuilder
 from ..document import DocumentImplementation
 from ..data_proxy import missing
 from ..data_objects import Reference
-from ..exceptions import NotCreatedError, UpdateError, DeleteError, ValidationError
+from ..exceptions import (
+    NotCreatedError, UpdateError, DeleteError, ValidationError, NoneReferenceError
+)
 from ..fields import ReferenceField, ListField, EmbeddedField
 from ..query_mapper import map_query
 
@@ -297,7 +299,7 @@ class TxMongoReference(Reference):
     def fetch(self, no_data=False, force_reload=False):
         if not self._document or force_reload:
             if self.pk is None:
-                raise ReferenceError('Cannot retrieve a None Reference')
+                raise NoneReferenceError('Cannot retrieve a None Reference')
             self._document = yield self.document_cls.find_one(self.pk)
             if not self._document:
                 raise ValidationError(self.error_messages['not_found'].format(


### PR DESCRIPTION
Closes #203.

- Rework exception.py.
- Replace ReferenceError with a custom umongo error (see #203).
- Expose exceptions meant to be caught in user code in a normal process (like update / delete error and such,...) and not those that should be noticed and fixed by the developer (document definition error,...). The choice is probably arguable but the other exceptions are available in umongo.exceptions anyway.