### PR TITLE
Don't modify data proxy on partial not loaded access

### DIFF
--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -379,12 +379,27 @@ class TestDataProxy(BaseTest):
         d.from_mongo({'loaded': "foo", 'loaded_but_empty': missing}, partial=True)
         assert d.partial is True
         for field in ('with_default', 'normal'):
+            val = d._data[field]
             with pytest.raises(exceptions.FieldNotLoadedError):
                 d.get(field)
+            assert d._data[field] == val
             with pytest.raises(exceptions.FieldNotLoadedError):
                 d.set(field, "test")
+            assert d._data[field] == val
             with pytest.raises(exceptions.FieldNotLoadedError):
                 d.delete(field)
+            assert d._data[field] == val
+        for field in ('normal', 'in_mongo_field'):
+            val = d._data[field]
+            with pytest.raises(exceptions.FieldNotLoadedError):
+                d.get_by_mongo_name(field)
+            assert d._data[field] == val
+            with pytest.raises(exceptions.FieldNotLoadedError):
+                d.set_by_mongo_name(field, "test")
+            assert d._data[field] == val
+            with pytest.raises(exceptions.FieldNotLoadedError):
+                d.delete_by_mongo_name(field)
+            assert d._data[field] == val
         assert d.get('loaded') == "foo"
         assert d.get('loaded_but_empty') is missing
         d.set('loaded_but_empty', "bar")

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -109,15 +109,14 @@ class BaseDataProxy:
         self._add_missing_fields()
 
     def get_by_mongo_name(self, name):
-        value = self._data[name]
         if self._fields_from_mongo_key[name] in self.not_loaded_fields:
             raise FieldNotLoadedError(name)
-        return value
+        return self._data[name]
 
     def set_by_mongo_name(self, name, value):
-        self._data[name] = value
         if self._fields_from_mongo_key[name] in self.not_loaded_fields:
             raise FieldNotLoadedError(name)
+        self._data[name] = value
         self._mark_as_modified(name)
 
     def delete_by_mongo_name(self, name):


### PR DESCRIPTION
Before this fix, `set_by_mongo_name` would raise but modify the data.