### PR TITLE
Add ExposeMissing context manager

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -569,7 +569,7 @@ from scratch... almost:
     >>> MassiveDuckSchema(marshmallow.Schema):
     ...     breeds = marshmallow.fields.List(marshmallow.fields.Nested(MassiveBreedSchema))
 
-.. note:: A custom marshmallow schema :class:`umongo.marshmallow_bonus.SchemaFromUmongo`
+.. note:: A custom marshmallow schema :class:`umongo.schema.RemoveMissingSchema`
     can be used instead of regular :class:`marshmallow.Schema` to skip missing fields
     when dumping a :class:`umongo.Document` object.
 

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -8,9 +8,8 @@ import marshmallow as ma
 
 from umongo import (
     Document, EmbeddedDocument, MixinDocument,
-    Schema, fields, exceptions, post_dump, pre_load, validates_schema
+    Schema, fields, exceptions, post_dump, pre_load, validates_schema, ExposeMissing
 )
-
 from .common import BaseTest
 
 
@@ -433,6 +432,14 @@ class TestDocument(BaseTest):
             del john['primary_key']
         with pytest.raises(exceptions.AlreadyCreatedError):
             john.update({'primary_key': ObjectId()})
+
+    def test_expose_missing(self):
+        john = self.Student(name='John Doe')
+        assert john.name == 'John Doe'
+        assert john.birthday is None
+        with ExposeMissing():
+            assert john.name == 'John Doe'
+            assert john.birthday is ma.missing
 
     def test_mixin(self):
 

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -5,7 +5,7 @@ import pytest
 import marshmallow as ma
 
 from umongo.data_proxy import data_proxy_factory
-from umongo import Document, EmbeddedDocument, MixinDocument, fields, exceptions
+from umongo import Document, EmbeddedDocument, MixinDocument, fields, exceptions, ExposeMissing
 
 from .common import BaseTest
 
@@ -413,6 +413,26 @@ class TestEmbeddedDocument(BaseTest):
         assert jane.name == john.name
         assert jane.child == john.child
         assert jane.child is not john.child
+
+    def test_expose_missing(self):
+        @self.instance.register
+        class Child(EmbeddedDocument):
+            name = fields.StrField()
+            age = fields.IntField()
+
+        @self.instance.register
+        class Parent(EmbeddedDocument):
+            name = fields.StrField()
+            child = fields.EmbeddedField(Child)
+
+        parent = Parent(**{'child': {'age': 42}})
+        assert parent.name is None
+        assert parent.child.name is None
+        assert parent.child.age == 42
+        with ExposeMissing():
+            assert parent.name is ma.missing
+            assert parent.child.name is ma.missing
+            assert parent.child.age == 42
 
     def test_mixin(self):
 

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -52,9 +52,15 @@ class TestMarshmallow(BaseTest):
         class MyDocument(Document):
             MA_BASE_SCHEMA_CLS = ExcludeBaseSchema
 
+            class Meta:
+                abstract = True
+
         @self.instance.register
         class MyEmbeddedDocument(EmbeddedDocument):
             MA_BASE_SCHEMA_CLS = ExcludeBaseSchema
+
+            class Meta:
+                abstract = True
 
         # Now, all our objects will generate "exclude" marshmallow schemas
         @self.instance.register
@@ -413,14 +419,14 @@ class TestMarshmallow(BaseTest):
             MA_BASE_SCHEMA_CLS = base_schema
 
             class Meta:
-                allow_inheritance = True
+                abstract = True
 
         @self.instance.register
         class MyEmbeddedDocument(EmbeddedDocument):
             MA_BASE_SCHEMA_CLS = base_schema
 
             class Meta:
-                allow_inheritance = True
+                abstract = True
 
         @self.instance.register
         class Accessory(MyEmbeddedDocument):
@@ -440,19 +446,17 @@ class TestMarshmallow(BaseTest):
         }
         dump = {
             'id': None,
-            'cls': 'Bag',
             'content': [
-                {'brief': 'cellphone', 'cls': 'Accessory', 'value': None},
-                {'brief': 'lighter', 'cls': 'Accessory', 'value': None}
+                {'brief': 'cellphone', 'value': None},
+                {'brief': 'lighter', 'value': None}
             ],
-            'item': {'brief': 'sportbag', 'cls': 'Accessory', 'value': None}
+            'item': {'brief': 'sportbag', 'value': None}
         }
         remove_missing_dump = {
-            'cls': 'Bag',
-            'item': {'cls': 'Accessory', 'brief': 'sportbag'},
+            'item': {'brief': 'sportbag'},
             'content': [
-                {'cls': 'Accessory', 'brief': 'cellphone'},
-                {'cls': 'Accessory', 'brief': 'lighter'}
+                {'brief': 'cellphone'},
+                {'brief': 'lighter'}
             ]
         }
         expected_dump = {

--- a/umongo/__init__.py
+++ b/umongo/__init__.py
@@ -29,6 +29,7 @@ from .schema import Schema
 from .data_objects import Reference
 from .embedded_document import EmbeddedDocument
 from .mixin import MixinDocument
+from .expose_missing import ExposeMissing
 from .i18n import set_gettext
 
 
@@ -52,6 +53,7 @@ __all__ = (
     'validates_schema',
     'EmbeddedDocument',
     'MixinDocument',
+    'ExposeMissing',
 
     'UMongoError',
     'ValidationError',

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -3,6 +3,7 @@ import marshmallow as ma
 
 from .template import Implementation, Template
 from .data_objects import BaseDataObject
+from .expose_missing import EXPOSE_MISSING
 from .exceptions import AbstractDocumentError
 
 
@@ -159,7 +160,7 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
 
     def __getitem__(self, name):
         value = self._data.get(name)
-        return value if value is not ma.missing else None
+        return None if value is ma.missing and not EXPOSE_MISSING.get() else value
 
     def __delitem__(self, name):
         self._data.delete(name)
@@ -182,7 +183,7 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
         if name[:2] == name[-2:] == '__':
             raise AttributeError(name)
         value = self._data.get(name, to_raise=AttributeError)
-        return value if value is not ma.missing else None
+        return None if value is ma.missing and not EXPOSE_MISSING.get() else value
 
     def __delattr__(self, name):
         if not self.__real_attributes:

--- a/umongo/expose_missing.py
+++ b/umongo/expose_missing.py
@@ -1,0 +1,26 @@
+"""Expose missing context variable
+
+Allows the user to let umongo document return missing rather than None for
+empty fields.
+"""
+
+
+from contextvars import ContextVar
+from contextlib import AbstractContextManager
+
+EXPOSE_MISSING = ContextVar("expose_missing", default=False)
+
+
+class ExposeMissing(AbstractContextManager):
+    """Let Document expose missing values rather than returning None
+
+    By default, getting a document item returns None if the value is missing.
+    Inside this context manager, the missing singleton is returned. This can
+    be useful is cases where the user want to distinguish between None and
+    missing value.
+    """
+    def __enter__(self):
+        self.token = EXPOSE_MISSING.set(True)
+
+    def __exit__(self, *args, **kwargs):
+        EXPOSE_MISSING.reset(self.token)

--- a/umongo/schema.py
+++ b/umongo/schema.py
@@ -3,7 +3,7 @@ import marshmallow as ma
 
 from .abstract import BaseSchema
 from .i18n import gettext as _
-
+from .expose_missing import ExposeMissing
 
 __all__ = (
     'Schema',
@@ -26,11 +26,8 @@ def schema_from_umongo_get_attribute(self, obj, attr, default):
             ...
 
     """
-    ret = ma.Schema.get_attribute(self, obj, attr, default)
-    if ret is None and ret is not default and attr in obj.schema.fields:
-        raw_ret = obj._data.get(attr)
-        return default if raw_ret is ma.missing else raw_ret
-    return ret
+    with ExposeMissing():
+        return ma.Schema.get_attribute(self, obj, attr, default)
 
 
 class SchemaFromUmongo(ma.Schema):

--- a/umongo/schema.py
+++ b/umongo/schema.py
@@ -7,27 +7,8 @@ from .expose_missing import ExposeMissing
 
 __all__ = (
     'Schema',
-    'schema_from_umongo_get_attribute',
     'RemoveMissingSchema',
 )
-
-
-def schema_from_umongo_get_attribute(self, obj, attr, default):
-    """
-    Overwrite default `Schema.get_attribute` method by this one to access
-        umongo missing fields instead of returning `None`.
-
-    example::
-
-        class MySchema(marshsmallow.Schema):
-            get_attribute = schema_from_umongo_get_attribute
-
-            # Define the rest of your schema
-            ...
-
-    """
-    with ExposeMissing():
-        return ma.Schema.get_attribute(self, obj, attr, default)
 
 
 class RemoveMissingSchema(ma.Schema):
@@ -63,10 +44,6 @@ class Schema(BaseSchema):
             for name, field in self.fields.items()
         }
         name = 'Marshmallow%s' % type(self).__name__
-        # By default OO world returns `missing` fields as `None`,
-        # disable this behavior here to let marshmallow deal with it
-        if not mongo_world:
-            nmspc['get_attribute'] = schema_from_umongo_get_attribute
         m_schema = type(name, (self.MA_BASE_SCHEMA_CLS, ), nmspc)
         # Add i18n support to the schema
         # We can't use I18nErrorDict here because __getitem__ is not called

--- a/umongo/schema.py
+++ b/umongo/schema.py
@@ -8,7 +8,7 @@ from .expose_missing import ExposeMissing
 __all__ = (
     'Schema',
     'schema_from_umongo_get_attribute',
-    'SchemaFromUmongo',
+    'RemoveMissingSchema',
 )
 
 
@@ -30,15 +30,14 @@ def schema_from_umongo_get_attribute(self, obj, attr, default):
         return ma.Schema.get_attribute(self, obj, attr, default)
 
 
-class SchemaFromUmongo(ma.Schema):
+class RemoveMissingSchema(ma.Schema):
     """
-    Custom :class:`marshmallow.Schema` subclass providing unknown fields
-    checking and custom get_attribute for umongo documents.
-
-    .. note: It is not mandatory to use this schema with umongo document.
-        This is just a helper providing usefull behaviors.
+    Custom :class:`marshmallow.Schema` subclass returning missing rather than
+    None for missing fields in umongo :class:`umongo.Document`s.
     """
-    get_attribute = schema_from_umongo_get_attribute
+    def dump(self, *args, **kwargs):
+        with ExposeMissing():
+            return super().dump(*args, **kwargs)
 
 
 class Schema(BaseSchema):


### PR DESCRIPTION
- Use Python 3.7's context variable feature to create a context manager in which a document returns missing for missing data rather than None
- Use this context manager in schema_from_umongo_get_attribute

This makes the Document responsible for outputing missing rather than the schema having to guess. Also the schema works with any type of data, not only a Document instance (with other data, the context manger is no-op).

I hoped to remove the whole `mongo_world` management thanks to this, but there are other issues with data from Mongo vs. Document.

The benefit is not as great as I expected, but I still like this implementation.