### PR TITLE
Set MA_BASE_SCHEMA_CLS in Document / EmbeddedDocument

### DIFF
--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -41,21 +41,57 @@ class TestMarshmallow(BaseTest):
         assert issubclass(ma_schema_cls, marshmallow.Schema)
         assert not issubclass(ma_schema_cls, BaseSchema)
 
-    def test_custom_base_schema(self):
+    def test_custom_ma_base_schema_cls(self):
 
-        class MyBaseSchema(marshmallow.Schema):
-            name = marshmallow.fields.Int()
-            age = marshmallow.fields.Int()
+        # Define custom marshmallow schema base class
+        class ExcludeBaseSchema(marshmallow.Schema):
+            class Meta:
+                unknown = marshmallow.EXCLUDE
 
-        ma_schema_cls = self.User.schema.as_marshmallow_schema(base_schema_cls=MyBaseSchema)
-        assert issubclass(ma_schema_cls, MyBaseSchema)
+        # Typically, we'll use it in all our schemas, so let's define base
+        # Document and EmbeddedDocument classes using this base schema class
+        @self.instance.register
+        class MyDocument(Document):
+            MA_BASE_SCHEMA_CLS = ExcludeBaseSchema
 
-        schema = ma_schema_cls()
-        assert schema.dump({'name': "42", 'age': 42, 'dummy': False}) == {'name': "42", 'age': 42}
-        with pytest.raises(marshmallow.ValidationError) as excinfo:
-            schema.load({'name': "42", 'age': 42, 'dummy': False})
-        assert excinfo.value.messages == {'dummy': ['Unknown field.']}
-        assert schema.load({'name': "42", 'age': 42}) == {'name': "42", 'age': 42}
+            class Meta:
+                allow_inheritance = True
+
+        @self.instance.register
+        class MyEmbeddedDocument(EmbeddedDocument):
+            MA_BASE_SCHEMA_CLS = ExcludeBaseSchema
+
+            class Meta:
+                allow_inheritance = True
+
+        # Now, all our objects will generate "exclude" marshmallow schemas
+        @self.instance.register
+        class Accessory(MyEmbeddedDocument):
+            brief = fields.StrField()
+            value = fields.IntField()
+
+        @self.instance.register
+        class Bag(MyDocument):
+            item = fields.EmbeddedField(Accessory)
+            content = fields.ListField(fields.EmbeddedField(Accessory))
+
+        data = {
+            'item': {'brief': 'sportbag', 'value': 100, 'name': 'Unknown'},
+            'content': [
+                {'brief': 'cellphone', 'value': 500, 'name': 'Unknown'},
+                {'brief': 'lighter', 'value': 2, 'name': 'Unknown'}
+            ],
+            'name': 'Unknown',
+        }
+        excl_data = {
+            'item': {'brief': 'sportbag', 'value': 100},
+            'content': [
+                {'brief': 'cellphone', 'value': 500},
+                {'brief': 'lighter', 'value': 2}]
+        }
+
+        ma_schema = Bag.schema.as_marshmallow_schema()
+        assert ma_schema().load(data) == excl_data
 
     def test_customize_params(self):
         ma_field = self.User.schema.fields['name'].as_marshmallow_field(params={'load_only': True})
@@ -113,39 +149,6 @@ class TestMarshmallow(BaseTest):
         assert ma_field.load_only is True
         assert ma_field.value_field.required is True
         assert ma_field.value_field.nested._declared_fields['value'].dump_only
-
-    def test_pass_meta_attributes(self):
-        @self.instance.register
-        class Accessory(EmbeddedDocument):
-            brief = fields.StrField(attribute='id', required=True)
-            value = fields.IntField()
-
-        @self.instance.register
-        class Bag(Document):
-            id = fields.EmbeddedField(Accessory, attribute='_id', required=True)
-            content = fields.ListField(fields.EmbeddedField(Accessory))
-            inventory = fields.DictField(fields.StringField, fields.EmbeddedField(Accessory))
-
-        ma_schema = Bag.schema.as_marshmallow_schema(meta={'exclude': ('id',)})
-        assert ma_schema.Meta.exclude == ('id',)
-        ma_schema = Bag.schema.as_marshmallow_schema(params={
-            'id': {'meta': {'exclude': ('value',)}}})
-        assert ma_schema._declared_fields['id'].nested.Meta.exclude == ('value',)
-        ma_schema = Bag.schema.as_marshmallow_schema(params={
-            'content': {'params': {'meta': {'exclude': ('value',)}}}})
-        assert ma_schema._declared_fields['content'].inner.nested.Meta.exclude == ('value',)
-        ma_schema = Bag.schema.as_marshmallow_schema(params={
-            'inventory': {'params': {'meta': {'exclude': ('value',)}}}})
-        assert ma_schema._declared_fields['inventory'].value_field.nested.Meta.exclude == ('value',)
-
-        class DumpOnlyIdSchema(marshmallow.Schema):
-            class Meta:
-                dump_only = ('id',)
-
-        ma_custom_base_schema = Bag.schema.as_marshmallow_schema(
-            base_schema_cls=DumpOnlyIdSchema, meta={'exclude': ('content',)})
-        assert ma_custom_base_schema.Meta.exclude == ('content',)
-        assert ma_custom_base_schema.Meta.dump_only == ('id',)
 
     def test_as_marshmallow_field_pass_params(self):
         @self.instance.register
@@ -207,18 +210,7 @@ class TestMarshmallow(BaseTest):
         assert new_ma_schema_cls != ma_schema_cls
 
         new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
-            meta={'exclude': ('name',)})
-        assert new_ma_schema_cls != ma_schema_cls
-
-        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
             mongo_world=True)
-        assert new_ma_schema_cls != ma_schema_cls
-
-        class MyBaseSchema(marshmallow.Schema):
-            pass
-
-        new_ma_schema_cls = self.User.schema.as_marshmallow_schema(
-            base_schema_cls=MyBaseSchema)
         assert new_ma_schema_cls != ma_schema_cls
 
         new_ma_schema_cls = self.User.schema.as_marshmallow_schema()
@@ -303,32 +295,31 @@ class TestMarshmallow(BaseTest):
             'birthday': ['OMG !!! Not a valid datetime.'],
             'dummy_field': ['OMG !!! Unknown field.']}
 
-    def test_unknown_fields_check(self):
+    def test_unknown_fields(self):
 
         class ExcludeBaseSchema(marshmallow.Schema):
             class Meta:
                 unknown = marshmallow.EXCLUDE
 
-        data = {'name': 'John', 'dummy_field': 'dummy'}
+        @self.instance.register
+        class ExcludeUser(self.User):
+            MA_BASE_SCHEMA_CLS = ExcludeBaseSchema
+
+        user_ma_schema_cls = self.User.schema.as_marshmallow_schema()
+        assert issubclass(user_ma_schema_cls, marshmallow.Schema)
+        exclude_user_ma_schema_cls = ExcludeUser.schema.as_marshmallow_schema()
+        assert issubclass(exclude_user_ma_schema_cls, ExcludeBaseSchema)
+
+        data = {'name': 'John', 'dummy': 'dummy'}
         excl_data = {'name': 'John'}
 
         # By default, marshmallow schemas raise on unknown fields
-        ma_schema_cls = self.User.schema.as_marshmallow_schema()
         with pytest.raises(marshmallow.ValidationError) as excinfo:
-            ma_schema_cls().load(data)
-        assert excinfo.value.messages == {'dummy_field': ['Unknown field.']}
+            user_ma_schema_cls().load(data)
+        assert excinfo.value.messages == {'dummy': ['Unknown field.']}
 
-        # Pass base schema with Meta.unknown = exclude unknown fields
-        ma_schema_cls = self.User.schema.as_marshmallow_schema(
-            base_schema_cls=ExcludeBaseSchema)
-        assert ma_schema_cls().load(data) == excl_data
-
-        # Pass meta to override base schema Meta
-        ma_schema_cls = self.User.schema.as_marshmallow_schema(
-            base_schema_cls=ExcludeBaseSchema,
-            meta={'unknown': marshmallow.INCLUDE}
-        )
-        assert ma_schema_cls().load(data) == data
+        # With custom schema, exclude unknown fields
+        assert exclude_user_ma_schema_cls().load(data) == excl_data
 
     def test_missing_accessor(self):
 
@@ -373,8 +364,9 @@ class TestMarshmallow(BaseTest):
             'id': {'brief': 'sportbag', 'value': 100},
             'content': [{'brief': 'cellphone', 'value': 500}, {'brief': 'lighter', 'value': 2}]
         }
-        # Here data is the same in both OO world and user world (no
-        # ObjectId to str conversion needed for example)
+
+        # Here data is the same in both OO world and user world
+        # (no ObjectId to str conversion needed for example)
 
         ma_schema = Bag.schema.as_marshmallow_schema()()
         ma_mongo_schema = Bag.schema.as_marshmallow_schema(mongo_world=True)()
@@ -385,54 +377,6 @@ class TestMarshmallow(BaseTest):
 
         assert ma_mongo_schema.dump(bag.to_mongo()) == data
         assert ma_mongo_schema.load(data) == bag.to_mongo()
-
-        # Check as_marshmallow_schema params (base_schema_cls)
-        # are passed to nested schemas
-        data = {
-            'id': {'brief': 'sportbag', 'value': 100, 'name': 'Unknown'},
-            'content': [
-                {'brief': 'cellphone', 'value': 500, 'name': 'Unknown'},
-                {'brief': 'lighter', 'value': 2, 'name': 'Unknown'}]
-        }
-        excl_data = {
-            'id': {'brief': 'sportbag', 'value': 100},
-            'content': [
-                {'brief': 'cellphone', 'value': 500},
-                {'brief': 'lighter', 'value': 2}]
-        }
-        with pytest.raises(marshmallow.ValidationError) as excinfo:
-            ma_schema.load(data)
-        assert excinfo.value.messages == {
-            'id': {'name': ['Unknown field.']},
-            'content': {
-                0: {'name': ['Unknown field.']},
-                1: {'name': ['Unknown field.']},
-            }}
-
-        class IncludeBaseSchema(marshmallow.Schema):
-            class Meta:
-                unknown = marshmallow.INCLUDE
-
-        # Pass base schema with Meta.unknown = include unknown fields
-        ma_include_schema = Bag.schema.as_marshmallow_schema(base_schema_cls=IncludeBaseSchema)()
-        assert ma_include_schema.load(data) == data
-
-        # Pass meta to override base schema Meta
-        ma_exclude_schema = Bag.schema.as_marshmallow_schema(
-            base_schema_cls=IncludeBaseSchema,
-            params={
-                'id': {'meta': {'unknown': marshmallow.EXCLUDE}},
-                'content': {'params': {'meta': {'unknown': marshmallow.EXCLUDE}}},
-            },
-            meta={'unknown': marshmallow.EXCLUDE}
-        )
-        assert ma_exclude_schema().load(data) == excl_data
-
-        class WithNameSchema(marshmallow.Schema):
-            name = marshmallow.fields.Str()
-
-        ma_custom_base_schema = Bag.schema.as_marshmallow_schema(base_schema_cls=WithNameSchema)
-        assert ma_custom_base_schema().load(data) == data
 
     def test_marshmallow_bonus_fields(self):
         # Fields related to mongodb provided for marshmallow

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -1,5 +1,5 @@
 from marshmallow import (Schema as MaSchema, fields as ma_fields,
-                         validate as ma_validate, missing, EXCLUDE)
+                         validate as ma_validate, missing)
 
 from .i18n import gettext as _, N_
 from .marshmallow_bonus import schema_from_umongo_get_attribute
@@ -39,24 +39,21 @@ class BaseSchema(MaSchema):
                 field.map_to_field(mongo_path, name, func)
 
     def as_marshmallow_schema(self, params=None, base_schema_cls=MaSchema,
-                              check_unknown_fields=True, mongo_world=False, meta=None):
+                              mongo_world=False, meta=None):
         """
         Return a pure-marshmallow version of this schema class.
 
         :param params: Per-field dict to pass parameters to their field creation.
         :param base_schema_cls: Class the schema will inherit from (
             default: :class:`marshmallow.Schema`).
-        :param check_unknown_fields: Unknown fields are considered as errors (default: True).
         :param mongo_world: If True the schema will work against the mongo world
             instead of the OO world (default: False).
         :param meta: Optional dict with attributes for the schema's Meta class.
         """
         params = params or {}
         meta = meta or {}
-        if not check_unknown_fields:
-            meta.setdefault('unknown', EXCLUDE)
         # Use hashable parameters as cache dict key and dict parameters for manual comparison
-        cache_key = (self.__class__, base_schema_cls, check_unknown_fields, mongo_world)
+        cache_key = (self.__class__, base_schema_cls, mongo_world)
         cache_modifiers = (params, meta)
         if cache_key in self._marshmallow_schemas_cache:
             for modifiers, ma_schema in self._marshmallow_schemas_cache[cache_key]:
@@ -65,9 +62,8 @@ class BaseSchema(MaSchema):
         nmspc = {
             name: field.as_marshmallow_field(
                 params=params.get(name),
-                base_schema_cls=base_schema_cls,
-                check_unknown_fields=check_unknown_fields,
-                mongo_world=mongo_world)
+                mongo_world=mongo_world,
+                base_schema_cls=base_schema_cls)
             for name, field in self.fields.items()
         }
         name = 'Marshmallow%s' % type(self).__name__

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -38,7 +38,7 @@ class BaseSchema(MaSchema):
             if hasattr(field, 'map_to_field'):
                 field.map_to_field(mongo_path, name, func)
 
-    def as_marshmallow_schema(self, params=None, base_schema_cls=MaSchema,
+    def as_marshmallow_schema(self, *, params=None, base_schema_cls=MaSchema,
                               mongo_world=False, meta=None):
         """
         Return a pure-marshmallow version of this schema class.
@@ -210,7 +210,7 @@ class BaseField(ma_fields.Field):
         params.update(self.metadata)
         return params
 
-    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
+    def as_marshmallow_field(self, *, params=None, mongo_world=False, **kwargs):
         """
         Return a pure-marshmallow version of this field.
 

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -53,6 +53,8 @@ class BaseSchema(MaSchema):
         """
         params = params or {}
         meta = meta or {}
+        if not check_unknown_fields:
+            meta.setdefault('unknown', EXCLUDE)
         # Use hashable parameters as cache dict key and dict parameters for manual comparison
         cache_key = (self.__class__, base_schema_cls, check_unknown_fields, mongo_world)
         cache_modifiers = (params, meta)
@@ -69,8 +71,6 @@ class BaseSchema(MaSchema):
             for name, field in self.fields.items()
         }
         name = 'Marshmallow%s' % type(self).__name__
-        if not check_unknown_fields:
-            meta.setdefault('unknown', EXCLUDE)
         # By default OO world returns `missing` fields as `None`,
         # disable this behavior here to let marshmallow deal with it
         if not mongo_world:

--- a/umongo/builder.py
+++ b/umongo/builder.py
@@ -262,6 +262,7 @@ class BaseBuilder:
         schema_nmspc = {}
         schema_nmspc.update(schema_fields)
         schema_nmspc.update(schema_non_fields)
+        schema_nmspc['MA_BASE_SCHEMA_CLS'] = template.MA_BASE_SCHEMA_CLS
         return type('%sSchema' % template.__name__, schema_bases, schema_nmspc)
 
     def build_document_from_template(self, template):

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -1,7 +1,10 @@
 from copy import deepcopy
 
 from bson import DBRef
-from marshmallow import pre_load, post_load, pre_dump, post_dump, validates_schema  # republishing
+from marshmallow import (
+    pre_load, post_load, pre_dump, post_dump, validates_schema,  # republishing
+    Schema as MaSchema
+)
 
 from .abstract import BaseDataObject
 from .data_proxy import missing
@@ -38,6 +41,7 @@ class DocumentTemplate(Template):
         or `marshmallow.post_dump`) to this class that will be passed
         to the marshmallow schema internally used for this document.
     """
+    MA_BASE_SCHEMA_CLS = MaSchema
 
 
 Document = DocumentTemplate

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -1,3 +1,5 @@
+import marshmallow as ma
+
 from .document import Implementation, Template
 from .data_objects import BaseDataObject
 from .data_proxy import missing
@@ -21,6 +23,7 @@ class EmbeddedDocumentTemplate(Template):
         :class:`umongo.instance.BaseInstance` to obtain it corresponding
         :class:`umongo.embedded_document.EmbeddedDocumentImplementation`.
     """
+    MA_BASE_SCHEMA_CLS = ma.Schema
 
 
 EmbeddedDocument = EmbeddedDocumentTemplate

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -218,18 +218,13 @@ class DictField(BaseField, ma_fields.Dict):
             )
         return Dict(self.key_field, self.value_field)
 
-    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
+    def as_marshmallow_field(self, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle deserialization
         # difference (`_id` vs `id`)
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
-        if params:
-            inner_params = params.pop('params', None)
-            field_kwargs.update(params)
-        else:
-            inner_params = None
         if self.value_field:
             inner_ma_schema = self.value_field.as_marshmallow_field(
-                mongo_world=mongo_world, params=inner_params, **kwargs)
+                mongo_world=mongo_world, **kwargs)
         else:
             inner_ma_schema = None
         return ma_fields.Dict(self.key_field, inner_ma_schema, **field_kwargs)
@@ -287,17 +282,12 @@ class ListField(BaseField, ma_fields.List):
         if hasattr(self.inner, 'map_to_field'):
             self.inner.map_to_field(mongo_path, path, func)
 
-    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
+    def as_marshmallow_field(self, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle deserialization
         # difference (`_id` vs `id`)
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
-        if params:
-            inner_params = params.pop('params', None)
-            field_kwargs.update(params)
-        else:
-            inner_params = None
         inner_ma_schema = self.inner.as_marshmallow_field(
-            mongo_world=mongo_world, params=inner_params, **kwargs)
+            mongo_world=mongo_world, **kwargs)
         return ma_fields.List(inner_ma_schema, **field_kwargs)
 
     def _required_validate(self, value):
@@ -388,12 +378,10 @@ class ReferenceField(BaseField, ma_bonus_fields.Reference):
     def _deserialize_from_mongo(self, value):
         return self.reference_cls(self.document_cls, value)
 
-    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
+    def as_marshmallow_field(self, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle deserialization
         # difference (`_id` vs `id`)
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
-        if params:
-            field_kwargs.update(params)
         return ma_bonus_fields.Reference(mongo_world=mongo_world, **field_kwargs)
 
 
@@ -446,12 +434,10 @@ class GenericReferenceField(BaseField, ma_bonus_fields.GenericReference):
         document_cls = self._document_cls(value['_cls'])
         return self.reference_cls(document_cls, value['_id'])
 
-    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
+    def as_marshmallow_field(self, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle deserialization
         # difference (`_id` vs `id`)
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
-        if params:
-            field_kwargs.update(params)
         return ma_bonus_fields.GenericReference(mongo_world=mongo_world, **field_kwargs)
 
 
@@ -566,16 +552,11 @@ class EmbeddedField(BaseField, ma_fields.Nested):
             if hasattr(field, 'map_to_field'):
                 field.map_to_field(cur_mongo_path, cur_path, func)
 
-    def as_marshmallow_field(self, params=None, mongo_world=False, **kwargs):
+    def as_marshmallow_field(self, mongo_world=False, **kwargs):
         # Overwrite default `as_marshmallow_field` to handle nesting
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
-        if params:
-            nested_params = params.pop('params', None)
-            field_kwargs.update(params)
-        else:
-            nested_params = None
         nested_ma_schema = self._embedded_document_cls.schema.as_marshmallow_schema(
-            params=nested_params, mongo_world=mongo_world)
+            mongo_world=mongo_world)
         return ma_fields.Nested(nested_ma_schema, **field_kwargs)
 
     def _required_validate(self, value):

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -576,8 +576,7 @@ class EmbeddedField(BaseField, ma_fields.Nested):
         else:
             nested_params = None
             nested_meta = None
-        schema_kwargs = {k: v for k, v in kwargs.items()
-                         if k in ('base_schema_cls', 'check_unknown_fields')}
+        schema_kwargs = {k: v for k, v in kwargs.items() if k == 'base_schema_cls'}
         nested_ma_schema = self._embedded_document_cls.schema.as_marshmallow_schema(
             params=nested_params, mongo_world=mongo_world, meta=nested_meta, **schema_kwargs)
         return ma_fields.Nested(nested_ma_schema, **field_kwargs)

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -571,14 +571,11 @@ class EmbeddedField(BaseField, ma_fields.Nested):
         field_kwargs = self._extract_marshmallow_field_params(mongo_world)
         if params:
             nested_params = params.pop('params', None)
-            nested_meta = params.pop('meta', None)
             field_kwargs.update(params)
         else:
             nested_params = None
-            nested_meta = None
-        schema_kwargs = {k: v for k, v in kwargs.items() if k == 'base_schema_cls'}
         nested_ma_schema = self._embedded_document_cls.schema.as_marshmallow_schema(
-            params=nested_params, mongo_world=mongo_world, meta=nested_meta, **schema_kwargs)
+            params=nested_params, mongo_world=mongo_world)
         return ma_fields.Nested(nested_ma_schema, **field_kwargs)
 
     def _required_validate(self, value):


### PR DESCRIPTION
This changes allows to set a base marshmallow schema class in the `Document` / `EmbeddedDocument` template.

It removes the complicated logic used to pass schema parameters (`check_unknown_fields`, `meta`, `params`) along the `as_marshmallow_schema` / `as_marshmallow_field` calls.

The former implementation passing params allows twisted cases like passing a specific parameter to a schema deeply nested in the document when calling `as_marshmallow_schema`, but in a way that is absolutely not practical: it takes a hugs unreadable dict as input.

In real life, schema parameters such as `unknown` are most often the same for all the application, so it makes sense to factorize them in a base schema.

Corner cases can always be addresses with this implementation. It might be a little bit more cumbersome, but it should be feasible and even more readable.

This PR also fixes the cache in `as_marshmallow_schema` that was broken in 3.0.0beta. The fix is in the first commit (set meta unknown in cache modifiers) but is obsoleted by subsequent commits.