### PR TITLE
Support mixins in (Embedded)Document definition

### DIFF
--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -441,3 +441,65 @@ class TestEmbeddedDocument(BaseTest):
         assert jane.name == john.name
         assert jane.child == john.child
         assert jane.child is not john.child
+
+    def test_mixin(self):
+
+        class PMixin:
+            pm = fields.IntField()
+
+        class CMixin:
+            cm = fields.IntField()
+
+        @self.instance.register
+        class Parent(PMixin, EmbeddedDocument):
+            p = fields.StrField()
+
+            class Meta:
+                allow_inheritance = True
+
+        @self.instance.register
+        class Child(CMixin, Parent):
+            c = fields.StrField()
+
+        assert set(Parent.schema.fields.keys()) == {'p', 'pm'}
+        assert set(Child.schema.fields.keys()) == {'cls', 'p', 'pm', 'c', 'cm'}
+
+        parent_data = {'p': 'parent', 'pm': 42}
+        child_data = {'c': 'Child', 'cm': 12, **parent_data}
+
+        assert Parent(**parent_data).dump() == parent_data
+        assert Child(**child_data).dump() == {**child_data, 'cls': 'Child'}
+
+    def test_mixin_override(self):
+
+        class PMixin:
+            pm = fields.IntField()
+
+        class CMixin:
+            cm = fields.IntField()
+
+        @self.instance.register
+        class Parent(PMixin, EmbeddedDocument):
+            p = fields.StrField()
+            pm = fields.IntField(validate=ma.validate.Range(0, 5))
+
+            class Meta:
+                allow_inheritance = True
+
+        @self.instance.register
+        class Child(CMixin, Parent):
+            c = fields.StrField()
+            cm = fields.IntField(validate=ma.validate.Range(0, 5))
+
+        assert set(Parent.schema.fields.keys()) == {'p', 'pm'}
+        assert set(Child.schema.fields.keys()) == {'cls', 'p', 'pm', 'c', 'cm'}
+
+        parent_data = {'p': 'parent', 'pm': 42}
+        child_data = {'c': 'Child', 'cm': 12, **parent_data}
+
+        with pytest.raises(ma.ValidationError) as exc:
+            Parent(**parent_data)
+        assert set(exc.value.messages.keys()) == {'pm'}
+        with pytest.raises(ma.ValidationError) as exc:
+            Child(**child_data)
+        assert set(exc.value.messages.keys()) == {'pm', 'cm'}


### PR DESCRIPTION
Closes #188.

This PR allows to use Mixin classes in `Document` and `EmbeddedDocument` definition.

It only works if the Mixin is declared first (leftmost) in the `Document` definition.

```py
class MyMixin:
    a = fields.IntField()

class MyDoc(MyMixin, Document):  # Mixin first
    b = fields.IntField()
```