### PR TITLE
Replace (Embedded)Document.real_attributes with _fields

### DIFF
--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -102,11 +102,14 @@ class TestDocument(BaseTest):
         with pytest.raises(AttributeError):
             john.missing
         with pytest.raises(AttributeError):
-            john.missing = None
-        with pytest.raises(AttributeError):
             del john.missing
         with pytest.raises(AttributeError):
-            del john.commit
+            del john.dump
+        john.dummy = 42
+        assert john.dummy == 42
+        del john.dummy
+        with pytest.raises(AttributeError):
+            john.dummy
 
     def test_fields_by_items(self):
         john = self.Student.build_from_mongo(data={

--- a/umongo/builder.py
+++ b/umongo/builder.py
@@ -298,6 +298,8 @@ class BaseBuilder:
         nmspc['schema'] = schema
         if base_tmpl_cls is not MixinDocumentTemplate:
             nmspc['DataProxy'] = data_proxy_factory(name, schema, strict=opts.strict)
+            # Add field names set as class attribute
+            nmspc['_fields'] = set(schema.fields.keys())
 
         if base_tmpl_cls is DocumentTemplate:
             # _build_document_opts cannot determine the indexes given we need to

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -92,19 +92,17 @@ class BaseDataProxy:
         # TODO: mark added missing fields as modified?
         self._add_missing_fields()
 
-    def _get_field(self, name, to_raise):
-        if name not in self._fields:
-            raise to_raise(name)
+    def _get_field(self, name):
         field = self._fields[name]
         name = field.attribute or name
         return name, field
 
-    def get(self, name, to_raise=KeyError):
-        name, _ = self._get_field(name, to_raise)
+    def get(self, name):
+        name, _ = self._get_field(name)
         return self._data[name]
 
-    def set(self, name, value, to_raise=KeyError):
-        name, field = self._get_field(name, to_raise)
+    def set(self, name, value):
+        name, field = self._get_field(name)
         if value is None and not getattr(field, 'allow_none', False):
             raise ma.ValidationError(field.error_messages['null'])
         if value is not None:
@@ -113,8 +111,8 @@ class BaseDataProxy:
         self._data[name] = value
         self._mark_as_modified(name)
 
-    def delete(self, name, to_raise=KeyError):
-        name, field = self._get_field(name, to_raise)
+    def delete(self, name):
+        name, field = self._get_field(name)
         default = field.default
         self._data[name] = default() if callable(default) else default
         self._mark_as_modified(name)

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -270,7 +270,7 @@ class DocumentImplementation(
         if name in self._fields:
             if self.is_created and name == self.pk_field:
                 raise AlreadyCreatedError("Can't modify id of a created document")
-            self._data.set(name, value, to_raise=AttributeError)
+            self._data.set(name, value)
         else:
             super().__setattr__(name, value)
 
@@ -278,7 +278,7 @@ class DocumentImplementation(
         if name in self._fields:
             if self.is_created and name == self.pk_field:
                 raise AlreadyCreatedError("Can't modify pk of a created document")
-            self._data.delete(name, to_raise=AttributeError)
+            self._data.delete(name)
         else:
             super().__delattr__(name)
 

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -169,18 +169,18 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
 
     def __setattr__(self, name, value):
         if name in self._fields:
-            self._data.set(name, value, to_raise=AttributeError)
+            self._data.set(name, value)
         else:
             super().__setattr__(name, value)
 
     def __getattr__(self, name):
-        if name[:2] == name[-2:] == '__':
-            raise AttributeError(name)
-        value = self._data.get(name, to_raise=AttributeError)
-        return None if value is ma.missing and not EXPOSE_MISSING.get() else value
+        if name in self._fields:
+            value = self._data.get(name)
+            return None if value is ma.missing and not EXPOSE_MISSING.get() else value
+        raise AttributeError(name)
 
     def __delattr__(self, name):
         if name in self._fields:
-            self._data.delete(name, to_raise=AttributeError)
+            self._data.delete(name)
         else:
             super().__delattr__(name)

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -87,7 +87,6 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
     """
 
     __slots__ = ('_data', )
-    __real_attributes = None
     opts = EmbeddedDocumentOpts(None, EmbeddedDocumentTemplate, abstract=True)
 
     def __init__(self, **kwargs):
@@ -169,15 +168,10 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
         self._data.set(name, value)
 
     def __setattr__(self, name, value):
-        # Try to retrieve name among class's attributes and __slots__
-        if not self.__real_attributes:
-            # `dir(self)` result only depend on self's class so we can
-            # compute it once and store it inside the class
-            type(self).__real_attributes = dir(self)
-        if name in self.__real_attributes:
-            object.__setattr__(self, name, value)
-        else:
+        if name in self._fields:
             self._data.set(name, value, to_raise=AttributeError)
+        else:
+            super().__setattr__(name, value)
 
     def __getattr__(self, name):
         if name[:2] == name[-2:] == '__':
@@ -186,9 +180,7 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
         return None if value is ma.missing and not EXPOSE_MISSING.get() else value
 
     def __delattr__(self, name):
-        if not self.__real_attributes:
-            type(self).__real_attributes = dir(self)
-        if name in self.__real_attributes:
-            object.__delattr__(self, name)
-        else:
+        if name in self._fields:
             self._data.delete(name, to_raise=AttributeError)
+        else:
+            super().__delattr__(name)


### PR DESCRIPTION
`_fields` is computed once on class creation rather than on first access
Allows setting arbitrary attributes on objects

----------------------

My first intent here was to fix an issue with fields from mixin classes. It appears the problem is more complicated than this (#271) so I'm not sure this change is worth it.

I don't really see the point of forbidding setting arbitrary attributes, so I'm still fine with this change. But I don't mind keeping things as they are as well.

I like the idea of setting the list at class creation time rather than on access, but I guess it could be achieved with real_attributes as well to keep current behaviour.

Note: See if to_raise argument in data proxy methods still has a meaning.