### PR TITLE
Test for projection error with default value 

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,5 +28,6 @@ def classroom_model(instance):
         name = fields.StrField(required=True)
         birthday = fields.DateTimeField()
         courses = fields.ListField(fields.ReferenceField(Course))
+        grade = fields.IntField(default=9)
 
     return namedtuple('Mapping', ('Teacher', 'Course', 'Student'))(Teacher, Course, Student)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,5 @@
 import pytest
+from datetime import datetime
 from functools import namedtuple
 
 from umongo import Document, fields
@@ -26,8 +27,7 @@ def classroom_model(instance):
     @instance.register
     class Student(Document):
         name = fields.StrField(required=True)
-        birthday = fields.DateTimeField()
+        birthday = fields.DateTimeField(default=datetime(1995, 12, 26))
         courses = fields.ListField(fields.ReferenceField(Course))
-        grade = fields.IntField(default=9)
 
     return namedtuple('Mapping', ('Teacher', 'Course', 'Student'))(Teacher, Course, Student)

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -163,7 +163,7 @@ class TestMotorAsyncio(BaseDBTest):
             await Student.collection.drop()
 
             for i in range(10):
-                await Student(name='student-%s' % i).commit()
+                await Student(name='student-%s' % i, birthday=datetime(1995, 12, 12)).commit()
             cursor = Student.find(limit=5, skip=6)
             if MOTOR_VERSION < (2, 0):
                 # this test doesn't make as much sense in motor>2.0, since the cursor no
@@ -235,16 +235,10 @@ class TestMotorAsyncio(BaseDBTest):
             students = list(await cursor.to_list(length=100))
             assert len(students) == 1
             assert students[0].name == 'student-0'
-
-            # Projection with default value in schema (birthday)
-            jane = Student(name='Jane Doe', birthday=datetime(1995, 12, 12))
-            await jane.commit()
-            cursor = Student.find({'name': 'Jane Doe'}, ['name'])
-            students = list(await cursor.to_list(length=100))
             # Birthday attribute should not be the default
             assert students[0].birthday != datetime(1995, 12, 26)
-            # Birthday attribute should be returned when selected
-            cursor = Student.find({'name': 'Jane Doe'}, ['name', 'birthday'])
+            # Defaulted birthday attribute should be returned when selected
+            cursor = Student.find({'name': 'student-0'}, ['name', 'birthday'])
             students = list(await cursor.to_list(length=100))
             assert students[0].birthday == datetime(1995, 12, 12)
 

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -237,16 +237,18 @@ class TestMotorAsyncio(BaseDBTest):
             assert students[0].name == 'student-0'
 
             # Projection with default value in schema (grade)
-            jane = Student(name='Jane Doe', birthday=datetime(1995, 12, 12), grade=10)
+            jane = Student(name='Jane Doe', birthday=datetime(1995, 12, 12))
             await jane.commit()
             cursor = Student.find({'name': 'Jane Doe'}, ['name'])
             students = list(await cursor.to_list(length=100))
-            # Grade attribute should be None becuase not part of projection
-            assert students[0].grade == None
-            # Grade attribute should be 10 when selected
-            cursor = Student.find({'name': 'Jane Doe'}, ['name', 'grade'])
+            # Birthday attribute should not be the default
+            assert students[0].birthday != datetime(1995, 12, 26)
+            # Birthday attribute should be None
+            assert students[0].birthday == None
+            # Birthday attribute should be returned when selected
+            cursor = Student.find({'name': 'Jane Doe'}, ['name', 'birthday'])
             students = list(await cursor.to_list(length=100))
-            assert students[0].grade == 10
+            assert students[0].birthday == datetime(1995, 12, 12)
 
         loop.run_until_complete(do_test())
 

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -236,6 +236,18 @@ class TestMotorAsyncio(BaseDBTest):
             assert len(students) == 1
             assert students[0].name == 'student-0'
 
+            # Projection with default value in schema (grade)
+            jane = Student(name='Jane Doe', birthday=datetime(1995, 12, 12), grade=10)
+            await jane.commit()
+            cursor = Student.find({'name': 'Jane Doe'}, ['name'])
+            students = list(await cursor.to_list(length=100))
+            # Grade attribute should be None becuase not part of projection
+            assert students[0].grade == None
+            # Grade attribute should be 10 when selected
+            cursor = Student.find({'name': 'Jane Doe'}, ['name', 'grade'])
+            students = list(await cursor.to_list(length=100))
+            assert students[0].grade == 10
+
         loop.run_until_complete(do_test())
 
     def test_classroom(self, loop, classroom_model):

--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -236,15 +236,13 @@ class TestMotorAsyncio(BaseDBTest):
             assert len(students) == 1
             assert students[0].name == 'student-0'
 
-            # Projection with default value in schema (grade)
+            # Projection with default value in schema (birthday)
             jane = Student(name='Jane Doe', birthday=datetime(1995, 12, 12))
             await jane.commit()
             cursor = Student.find({'name': 'Jane Doe'}, ['name'])
             students = list(await cursor.to_list(length=100))
             # Birthday attribute should not be the default
             assert students[0].birthday != datetime(1995, 12, 26)
-            # Birthday attribute should be None
-            assert students[0].birthday == None
             # Birthday attribute should be returned when selected
             cursor = Student.find({'name': 'Jane Doe'}, ['name', 'birthday'])
             students = list(await cursor.to_list(length=100))


### PR DESCRIPTION
Offshoot of https://github.com/Scille/umongo/issues/268

Wrote a sample test for the issue: If a user does not include any defaulted values in a projection and the field contains a value other than the default value, the projection incorrectly returns the default value. I  believe the underlying issue is that the default value is automatically added to the umongo object if it doesn't get returned from a query. In the below test when the projection is performed for name the Student object returned has a value of (1995, 12, 26) for birthday even though Jane's birthday is (1995, 12, 12) in the db. I think that the projection should return None as it does for non-default specified columns