### PR TITLE
Fixed `allow_none` on embedded list

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -88,6 +88,19 @@ class TestRequired(BaseTest):
         doc.required_validate()
 
 
+    def test_allow_none_nested_list(self):
+        @self.instance.register
+        class MyEmbedded(EmbeddedDocument):
+            field = fields.IntField()
+
+        @self.instance.register
+        class MyDoc(Document):
+            embedded_list = fields.ListField(fields.EmbeddedField(MyEmbedded), allow_none=True)
+
+        # List with `allow_none` should be allowed `None`
+        MyDoc(embedded_list=None).required_validate()
+
+
 class TestFields(BaseTest):
 
     def test_basefields(self):

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -293,6 +293,8 @@ class ListField(BaseField, ma.fields.List):
     def _required_validate(self, value):
         if value is ma.missing or not hasattr(self.inner, '_required_validate'):
             return
+        if value is None and getattr(self, 'allow_none', False) is True:
+            return None
         required_validate = self.inner._required_validate
         errors = {}
         for i, sub_value in enumerate(value):


### PR DESCRIPTION
I realized, that when I have a `fields.ListField(fields.EmbeddedField(MyEmbedded), allow_none=True)`, a `TypeError` is raised, when `enumerate(value)` in `_required_validate(...)` is called. 
So I added another check for the `allow_none` attribute and skip this per-item validation.