### PR TITLE
Allow passing Document and EmbeddedDocument in queries

### DIFF
--- a/tests/test_query_mapper.py
+++ b/tests/test_query_mapper.py
@@ -1,5 +1,7 @@
 import datetime as dt
 
+from bson import ObjectId
+
 from umongo import Document, EmbeddedDocument, fields
 from umongo.query_mapper import map_query
 
@@ -11,6 +13,10 @@ class TestQueryMapper(BaseTest):
     def test_query_mapper(self):
 
         @self.instance.register
+        class Editor(Document):
+            name = fields.StrField()
+
+        @self.instance.register
         class Author(EmbeddedDocument):
             name = fields.StrField()
             birthday = fields.DateTimeField(attribute='b')
@@ -19,7 +25,6 @@ class TestQueryMapper(BaseTest):
         class Chapter(EmbeddedDocument):
             title = fields.StrField()
             pagination = fields.IntField(attribute='p')
-            # sub_chapters = fields.EmbeddedField('Chapter')
 
         @self.instance.register
         class Book(Document):
@@ -28,6 +33,7 @@ class TestQueryMapper(BaseTest):
             author = fields.EmbeddedField(Author, attribute='a')
             chapters = fields.ListField(fields.EmbeddedField(Chapter))
             tags = fields.ListField(fields.StrField(), attribute='t')
+            editor = fields.ReferenceField(Editor, attribute='e')
 
         book_fields = Book.schema.fields
         # No changes needed
@@ -108,6 +114,13 @@ class TestQueryMapper(BaseTest):
         assert query == {
             'a': {'name': 'JRR Tolkien', 'b': dt.datetime(1892, 1, 3)}
         }
+
+        # Test document in query
+        editor = Editor(name='Allen & Unwin')
+        editor.id = ObjectId()
+        query = map_query({'editor': editor}, book_fields)
+        assert isinstance(query['e'], ObjectId)
+        assert query['e'] == editor.id
 
     def test_mix(self):
 

--- a/tests/test_query_mapper.py
+++ b/tests/test_query_mapper.py
@@ -100,6 +100,15 @@ class TestQueryMapper(BaseTest):
             ]}
         }
 
+        # Test embedded document in query
+        query = map_query({
+            'author': Author(name='JRR Tolkien', birthday=dt.datetime(1892, 1, 3))
+        }, book_fields)
+        assert isinstance(query['a'], dict)
+        assert query == {
+            'a': {'name': 'JRR Tolkien', 'b': dt.datetime(1892, 1, 3)}
+        }
+
     def test_mix(self):
 
         @self.instance.register

--- a/umongo/query_mapper.py
+++ b/umongo/query_mapper.py
@@ -1,4 +1,5 @@
 from umongo.fields import ListField, EmbeddedField
+from umongo.document import DocumentImplementation
 from umongo.embedded_document import EmbeddedDocumentImplementation
 
 
@@ -45,6 +46,9 @@ def map_query(query, fields):
         return mapped_query
     if isinstance(query, (list, tuple)):
         return [map_query(x, fields) for x in query]
+    # Passing a Document only makes sense in a Reference, let's query on ObjectId
+    if isinstance(query, DocumentImplementation):
+        return query.pk
     if isinstance(query, EmbeddedDocumentImplementation):
         return query.to_mongo()
     return query

--- a/umongo/query_mapper.py
+++ b/umongo/query_mapper.py
@@ -1,4 +1,5 @@
 from umongo.fields import ListField, EmbeddedField
+from umongo.embedded_document import EmbeddedDocumentImplementation
 
 
 def map_entry(entry, fields):
@@ -44,4 +45,6 @@ def map_query(query, fields):
         return mapped_query
     if isinstance(query, (list, tuple)):
         return [map_query(x, fields) for x in query]
+    if isinstance(query, EmbeddedDocumentImplementation):
+        return query.to_mongo()
     return query


### PR DESCRIPTION
Document is considered a reference and the pk is passed.

EmbeddedDocument is dumped in the query.