### PR TITLE
Add replace argument to commit method

### DIFF
--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -97,6 +97,33 @@ class TestMotorAsyncio(BaseDBTest):
 
         loop.run_until_complete(do_test())
 
+    def test_replace(self, loop, classroom_model):
+        Student = classroom_model.Student
+
+        async def do_test():
+            john = Student(name='John Doe', birthday=dt.datetime(1995, 12, 12))
+            # replace has no impact on creation
+            await john.commit(replace=True)
+            john.name = 'William Doe'
+            john.clear_modified()
+            ret = await john.commit(replace=True)
+            assert isinstance(ret, UpdateResult)
+            john2 = await Student.find_one(john.id)
+            assert john2._data == john._data
+            # Test conditional commit
+            john.name = 'Zorro Doe'
+            john.clear_modified()
+            with pytest.raises(exceptions.UpdateError):
+                await john.commit(conditions={'name': 'Bad Name'}, replace=True)
+            await john.commit(conditions={'name': 'William Doe'}, replace=True)
+            await john.reload()
+            assert john.name == 'Zorro Doe'
+            # Cannot use conditions when creating document
+            with pytest.raises(exceptions.NotCreatedError):
+                await Student(name='Joe').commit(conditions={'name': 'dummy'}, replace=True)
+
+        loop.run_until_complete(do_test())
+
     def test_remove(self, loop, classroom_model):
         Student = classroom_model.Student
 

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -102,6 +102,30 @@ class TestTxMongo(BaseDBTest):
             yield Student(name='Joe').commit(conditions={'name': 'dummy'})
 
     @pytest_inlineCallbacks
+    def test_replace(self, classroom_model):
+        Student = classroom_model.Student
+        john = Student(name='John Doe', birthday=dt.datetime(1995, 12, 12))
+        # replace has no impact on creation
+        yield john.commit(replace=True)
+        john.name = 'William Doe'
+        john.clear_modified()
+        ret = yield john.commit(replace=True)
+        assert isinstance(ret, UpdateResult)
+        john2 = yield Student.find_one(john.id)
+        assert john2._data == john._data
+        # Test conditional commit
+        john.name = 'Zorro Doe'
+        john.clear_modified()
+        with pytest.raises(exceptions.UpdateError):
+            yield john.commit(conditions={'name': 'Bad Name'}, replace=True)
+        yield john.commit(conditions={'name': 'William Doe'}, replace=True)
+        yield john.reload()
+        assert john.name == 'Zorro Doe'
+        # Cannot use conditions when creating document
+        with pytest.raises(exceptions.NotCreatedError):
+            yield Student(name='Joe').commit(conditions={'name': 'dummy'}, replace=True)
+
+    @pytest_inlineCallbacks
     def test_delete(self, classroom_model):
         Student = classroom_model.Student
         yield Student.collection.drop()

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -38,7 +38,7 @@ class TxMongoDocument(DocumentImplementation):
         self._data.from_mongo(ret)
 
     @inlineCallbacks
-    def commit(self, io_validate_all=False, conditions=None):
+    def commit(self, io_validate_all=False, conditions=None, replace=False):
         """
         Commit the document in database.
         If the document doesn't already exist it will be inserted, otherwise
@@ -49,12 +49,13 @@ class TxMongoDocument(DocumentImplementation):
             satisfies condition(s) (e.g. version number).
             Raises :class:`umongo.exceptions.UpdateError` if the
             conditions are not satisfied.
-         :return: A :class:`pymongo.results.UpdateResult` or
+        :param replace: Replace the document rather than update.
+        :return: A :class:`pymongo.results.UpdateResult` or
             :class:`pymongo.results.InsertOneResult` depending of the operation.
        """
         try:
             if self.is_created:
-                if self.is_modified():
+                if self.is_modified() or replace:
                     query = conditions or {}
                     query['_id'] = self.pk
                     # pre_update can provide additional query filter and/or
@@ -64,8 +65,12 @@ class TxMongoDocument(DocumentImplementation):
                         query.update(map_query(additional_filter, self.schema.fields))
                     self.required_validate()
                     yield self.io_validate(validate_all=io_validate_all)
-                    payload = self._data.to_mongo(update=True)
-                    ret = yield self.collection.update_one(query, payload)
+                    if replace:
+                        payload = self._data.to_mongo(update=False)
+                        ret = yield self.collection.replace_one(query, payload)
+                    else:
+                        payload = self._data.to_mongo(update=True)
+                        ret = yield self.collection.update_one(query, payload)
                     if ret.matched_count != 1:
                         raise UpdateError(ret)
                     yield maybeDeferred(self.post_update, ret)


### PR DESCRIPTION
This should not be useful in everyday use. But it may come in handy for maintenance tasks, to rewrite documents from scratch:

- Fix document broken by another tool
- Write migration tool