### PR TITLE
Rework instance

### DIFF
--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -9,11 +9,8 @@ API Reference
 Instance
 ========
 
-.. autoclass:: umongo.instance.BaseInstance
-    :inherited-members:
-
-.. autoclass:: umongo.Instance
-  :members:
+.. autoclass:: umongo.instance.Instance
+    :members:
 
 .. autoclass:: umongo.PyMongoInstance
 

--- a/docs/apireference.rst
+++ b/docs/apireference.rst
@@ -13,8 +13,6 @@ Instance
     :inherited-members:
 
 .. autoclass:: umongo.Instance
-
-.. autoclass:: umongo.instance.LazyLoaderInstance
   :members:
 
 .. autoclass:: umongo.PyMongoInstance

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,7 +1,7 @@
 import pymongo
 
 from umongo.document import DocumentImplementation
-from umongo.instance import Instance, LazyLoaderInstance
+from umongo.instance import Instance
 from umongo.builder import BaseBuilder
 from umongo.frameworks import register_instance
 
@@ -58,7 +58,7 @@ class MockedBuilder(BaseBuilder):
     BASE_DOCUMENT_CLS = DocumentImplementation
 
 
-class MockedInstance(LazyLoaderInstance):
+class MockedInstance(Instance):
     BUILDER_CLS = MockedBuilder
 
     @staticmethod

--- a/tests/common.py
+++ b/tests/common.py
@@ -3,7 +3,7 @@ import pymongo
 from umongo.document import DocumentImplementation
 from umongo.instance import Instance, LazyLoaderInstance
 from umongo.builder import BaseBuilder
-from umongo.frameworks import register_builder
+from umongo.frameworks import register_instance
 
 
 TEST_DB = 'umongo_test'
@@ -57,22 +57,22 @@ class MockedBuilder(BaseBuilder):
 
     BASE_DOCUMENT_CLS = DocumentImplementation
 
+
+class MockedInstance(LazyLoaderInstance):
+    BUILDER_CLS = MockedBuilder
+
     @staticmethod
     def is_compatible_with(db):
         return isinstance(db, MockedDB)
 
 
-register_builder(MockedBuilder)
-
-
-class MockedInstance(LazyLoaderInstance):
-    BUILDER_CLS = MockedBuilder
+register_instance(MockedInstance)
 
 
 class BaseTest:
 
     def setup(self):
-        self.instance = Instance(MockedDB('my_moked_db'))
+        self.instance = Instance.from_db(MockedDB('my_moked_db'))
 
 
 class BaseDBTest:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ from umongo.instance import Instance
 @pytest.fixture
 def instance(db):
     # `db` should be a fixture provided by the current framework's testbench
-    return Instance(db)
+    return Instance.from_db(db)
 
 
 @pytest.fixture

--- a/tests/test_builder.py
+++ b/tests/test_builder.py
@@ -2,7 +2,7 @@ import pytest
 
 from umongo.frameworks import InstanceRegisterer
 from umongo.builder import BaseBuilder
-from umongo.instance import LazyLoaderInstance
+from umongo.instance import Instance
 from umongo.document import DocumentImplementation
 from umongo.exceptions import NoCompatibleInstanceError
 
@@ -13,7 +13,7 @@ def create_env(prefix):
     builder_cls = type(f"{prefix}Builder", (BaseBuilder, ), {
         'BASE_DOCUMENT_CLS': document_cls,
     })
-    instance_cls = type(f"{prefix}Instance", (LazyLoaderInstance, ), {
+    instance_cls = type(f"{prefix}Instance", (Instance, ), {
         'BUILDER_CLS': builder_cls,
         'is_compatible_with': staticmethod(lambda db: isinstance(db, db_cls))
     })

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -17,12 +17,14 @@ from .common import MockedDB, MockedInstance
 
 
 # Try to retrieve framework's db to test against each of them
-DB_AND_INSTANCE_PER_FRAMEWORK = [(MockedDB('my_db'), MockedInstance)]
+DB_AND_INSTANCE_PER_FRAMEWORK = [
+    (MockedDB('my_db'), MockedInstance),
+]
 for mod_name, inst_name in (
         ('mongomock', 'MongoMockInstance'),
         ('motor_asyncio', 'MotorAsyncIOInstance'),
         ('txmongo', 'TxMongoInstance'),
-        ('pymongo', 'PyMongoInstance')
+        ('pymongo', 'PyMongoInstance'),
 ):
     inst = getattr(umongo.frameworks, inst_name, None)
     if inst is not None:

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -75,8 +75,8 @@ class TestInstance:
             Doc2(nested={})
 
     def test_multiple_instances(self, db):
-        instance1 = Instance(db)
-        instance2 = Instance(db)
+        instance1 = Instance.from_db(db)
+        instance2 = Instance.from_db(db)
 
         class Doc(Document):
             pass
@@ -99,8 +99,8 @@ class TestInstance:
         assert Embedded2.opts.instance is instance2
 
     def test_register_other_implementation(self, db):
-        instance1 = Instance(db)
-        instance2 = Instance(db)
+        instance1 = Instance.from_db(db)
+        instance2 = Instance.from_db(db)
 
         class Doc(Document):
             pass
@@ -191,8 +191,8 @@ class TestInstance:
 
     def test_patched_fields(self, db):
 
-        instance1 = Instance(db)
-        instance2 = Instance(db)
+        instance1 = Instance.from_db(db)
+        instance2 = Instance.from_db(db)
 
         class Embedded(EmbeddedDocument):
             simple = fields.IntField()

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -184,10 +184,10 @@ class TestInstance:
 
         doc_impl_cls = instance.register(Doc)
 
-        with pytest.raises(NoDBDefinedError):
+        with pytest.raises(NoDBDefinedError, match="db not set, please call set_db"):
             doc_impl_cls.collection
 
-        instance.init(db)
+        instance.set_db(db)
 
         assert doc_impl_cls.collection == db['doc']
 

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -8,9 +8,7 @@ from umongo import Document, fields, EmbeddedDocument
 from umongo.instance import Instance
 from umongo.document import DocumentTemplate, DocumentImplementation
 from umongo.embedded_document import EmbeddedDocumentTemplate, EmbeddedDocumentImplementation
-from umongo.frameworks import (
-    MongoMockInstance, MotorAsyncIOInstance, TxMongoInstance, PyMongoInstance
-)
+import umongo.frameworks
 from umongo.exceptions import (
     AlreadyRegisteredDocumentError, NotRegisteredDocumentError, NoDBDefinedError
 )
@@ -20,12 +18,15 @@ from .common import MockedDB, MockedInstance
 
 # Try to retrieve framework's db to test against each of them
 DB_AND_INSTANCE_PER_FRAMEWORK = [(MockedDB('my_db'), MockedInstance)]
-for name, inst in (('mongomock', MongoMockInstance),
-                   ('motor_asyncio', MotorAsyncIOInstance),
-                   ('txmongo', TxMongoInstance),
-                   ('pymongo', PyMongoInstance)):
-    mod = importlib.import_module('tests.frameworks.test_%s' % name)
-    if not mod.dep_error:
+for mod_name, inst_name in (
+        ('mongomock', 'MongoMockInstance'),
+        ('motor_asyncio', 'MotorAsyncIOInstance'),
+        ('txmongo', 'TxMongoInstance'),
+        ('pymongo', 'PyMongoInstance')
+):
+    inst = getattr(umongo.frameworks, inst_name, None)
+    if inst is not None:
+        mod = importlib.import_module(f"tests.frameworks.test_{mod_name}")
         DB_AND_INSTANCE_PER_FRAMEWORK.append((mod.make_db(), inst))
 
 

--- a/umongo/__init__.py
+++ b/umongo/__init__.py
@@ -1,12 +1,7 @@
 from marshmallow import ValidationError, missing  # noqa, republishing
 
 from .instance import Instance
-from .frameworks import (
-    PyMongoInstance,
-    TxMongoInstance,
-    MotorAsyncIOInstance,
-    MongoMockInstance
-)
+
 from .document import (
     Document,
     pre_load,
@@ -39,10 +34,6 @@ __all__ = (
     'missing',
 
     'Instance',
-    'PyMongoInstance',
-    'TxMongoInstance',
-    'MotorAsyncIOInstance',
-    'MongoMockInstance',
 
     'Document',
     'pre_load',

--- a/umongo/exceptions.py
+++ b/umongo/exceptions.py
@@ -5,8 +5,8 @@ class UMongoError(Exception):
     """Base umongo error"""
 
 
-class NoCompatibleBuilderError(UMongoError):
-    """Can't find builder compatible with database"""
+class NoCompatibleInstanceError(UMongoError):
+    """Can't find instance compatible with database"""
 
 
 class AbstractDocumentError(UMongoError):

--- a/umongo/frameworks/__init__.py
+++ b/umongo/frameworks/__init__.py
@@ -2,9 +2,6 @@
 Frameworks
 ==========
 """
-
-from importlib import import_module
-
 from ..exceptions import NoCompatibleBuilderError
 from ..instance import LazyLoaderInstance
 from .pymongo import PyMongoBuilder
@@ -59,52 +56,49 @@ class PyMongoInstance(LazyLoaderInstance):
     """
     :class:`umongo.instance.LazyLoaderInstance` implementation for pymongo
     """
-    def __init__(self, *args, **kwargs):
-        self.BUILDER_CLS = import_module('umongo.frameworks.pymongo').PyMongoBuilder
-        super().__init__(*args, **kwargs)
+    BUILDER_CLS = PyMongoBuilder
 
 
-class TxMongoInstance(LazyLoaderInstance):
-    """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo
-    """
-    def __init__(self, *args, **kwargs):
-        self.BUILDER_CLS = import_module('umongo.frameworks.txmongo').TxMongoBuilder
-        super().__init__(*args, **kwargs)
-
-
-class MotorAsyncIOInstance(LazyLoaderInstance):
-    """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for motor-asyncio
-    """
-    def __init__(self, *args, **kwargs):
-        self.BUILDER_CLS = import_module('umongo.frameworks.motor_asyncio').MotorAsyncIOBuilder
-        super().__init__(*args, **kwargs)
-
-
-class MongoMockInstance(LazyLoaderInstance):
-    """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for mongomock
-    """
-    def __init__(self, *args, **kwargs):
-        self.BUILDER_CLS = import_module('umongo.frameworks.mongomock').MongoMockBuilder
-        super().__init__(*args, **kwargs)
-
-
-# try to load all the builders by default
 register_builder(PyMongoBuilder)
+
+
 try:
     from .txmongo import TxMongoBuilder
     register_builder(TxMongoBuilder)
+
+    class TxMongoInstance(LazyLoaderInstance):
+        """
+        :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo
+        """
+        BUILDER_CLS = TxMongoBuilder
+
 except ImportError:  # pragma: no cover
     pass
+
+
 try:
     from .motor_asyncio import MotorAsyncIOBuilder
     register_builder(MotorAsyncIOBuilder)
+
+    class MotorAsyncIOInstance(LazyLoaderInstance):
+        """
+        :class:`umongo.instance.LazyLoaderInstance` implementation for motor-asyncio
+        """
+        BUILDER_CLS = MotorAsyncIOBuilder
+
 except ImportError:  # pragma: no cover
     pass
+
+
 try:
     from .mongomock import MongoMockBuilder
     register_builder(MongoMockBuilder)
+
+    class MongoMockInstance(LazyLoaderInstance):
+        """
+        :class:`umongo.instance.LazyLoaderInstance` implementation for mongomock
+        """
+        BUILDER_CLS = MongoMockBuilder
+
 except ImportError:  # pragma: no cover
     pass

--- a/umongo/frameworks/__init__.py
+++ b/umongo/frameworks/__init__.py
@@ -3,8 +3,7 @@ Frameworks
 ==========
 """
 from ..exceptions import NoCompatibleBuilderError
-from ..instance import LazyLoaderInstance
-from .pymongo import PyMongoBuilder
+from .pymongo import PyMongoBuilder, PyMongoInstance
 
 
 __all__ = (
@@ -52,53 +51,25 @@ find_builder_from_db = default_builder_registerer.find_from_db
 
 # Define lazy loader instances for each builder
 
-class PyMongoInstance(LazyLoaderInstance):
-    """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for pymongo
-    """
-    BUILDER_CLS = PyMongoBuilder
-
-
 register_builder(PyMongoBuilder)
 
 
 try:
-    from .txmongo import TxMongoBuilder
+    from .txmongo import TxMongoBuilder, TxMongoInstance
     register_builder(TxMongoBuilder)
-
-    class TxMongoInstance(LazyLoaderInstance):
-        """
-        :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo
-        """
-        BUILDER_CLS = TxMongoBuilder
-
 except ImportError:  # pragma: no cover
     pass
 
 
 try:
-    from .motor_asyncio import MotorAsyncIOBuilder
+    from .motor_asyncio import MotorAsyncIOBuilder, MotorAsyncIOInstance
     register_builder(MotorAsyncIOBuilder)
-
-    class MotorAsyncIOInstance(LazyLoaderInstance):
-        """
-        :class:`umongo.instance.LazyLoaderInstance` implementation for motor-asyncio
-        """
-        BUILDER_CLS = MotorAsyncIOBuilder
-
 except ImportError:  # pragma: no cover
     pass
 
 
 try:
-    from .mongomock import MongoMockBuilder
+    from .mongomock import MongoMockBuilder, MongoMockInstance
     register_builder(MongoMockBuilder)
-
-    class MongoMockInstance(LazyLoaderInstance):
-        """
-        :class:`umongo.instance.LazyLoaderInstance` implementation for mongomock
-        """
-        BUILDER_CLS = MongoMockBuilder
-
 except ImportError:  # pragma: no cover
     pass

--- a/umongo/frameworks/__init__.py
+++ b/umongo/frameworks/__init__.py
@@ -2,17 +2,17 @@
 Frameworks
 ==========
 """
-from ..exceptions import NoCompatibleBuilderError
-from .pymongo import PyMongoBuilder, PyMongoInstance
+from ..exceptions import NoCompatibleInstanceError
+from .pymongo import PyMongoInstance
 
 
 __all__ = (
-    'BuilderRegisterer',
+    'InstanceRegisterer',
 
-    'default_builder_registerer',
-    'register_builder',
-    'unregister_builder',
-    'find_builder_from_db',
+    'default_instance_registerer',
+    'register_instance',
+    'unregister_instance',
+    'find_instance_from_db',
 
     'PyMongoInstance',
     'TxMongoInstance',
@@ -21,55 +21,55 @@ __all__ = (
 )
 
 
-class BuilderRegisterer:
+class InstanceRegisterer:
 
     def __init__(self):
-        self.builders = []
+        self.instances = []
 
-    def register(self, builder):
-        if builder not in self.builders:
-            # Insert new item first to overload older compatible builders
-            self.builders.insert(0, builder)
+    def register(self, instance):
+        if instance not in self.instances:
+            # Insert new item first to overload older compatible instances
+            self.instances.insert(0, instance)
 
-    def unregister(self, builder):
+    def unregister(self, instance):
         # Basically only used for tests
-        self.builders.remove(builder)
+        self.instances.remove(instance)
 
     def find_from_db(self, db):
-        for builder in self.builders:
-            if builder.is_compatible_with(db):
-                return builder
-        raise NoCompatibleBuilderError(
-            'Cannot find a umongo builder compatible with %s' % type(db))
+        for instance in self.instances:
+            if instance.is_compatible_with(db):
+                return instance
+        raise NoCompatibleInstanceError(
+            'Cannot find a umongo instance compatible with %s' % type(db))
 
 
-default_builder_registerer = BuilderRegisterer()
-register_builder = default_builder_registerer.register
-unregister_builder = default_builder_registerer.unregister
-find_builder_from_db = default_builder_registerer.find_from_db
+default_instance_registerer = InstanceRegisterer()
+register_instance = default_instance_registerer.register
+unregister_instance = default_instance_registerer.unregister
+find_instance_from_db = default_instance_registerer.find_from_db
 
 
-# Define lazy loader instances for each builder
+# Define lazy loader instances for each instance
 
-register_builder(PyMongoBuilder)
+register_instance(PyMongoInstance)
 
 
 try:
-    from .txmongo import TxMongoBuilder, TxMongoInstance
-    register_builder(TxMongoBuilder)
+    from .txmongo import TxMongoInstance
+    register_instance(TxMongoInstance)
 except ImportError:  # pragma: no cover
     pass
 
 
 try:
-    from .motor_asyncio import MotorAsyncIOBuilder, MotorAsyncIOInstance
-    register_builder(MotorAsyncIOBuilder)
+    from .motor_asyncio import MotorAsyncIOInstance
+    register_instance(MotorAsyncIOInstance)
 except ImportError:  # pragma: no cover
     pass
 
 
 try:
-    from .mongomock import MongoMockBuilder, MongoMockInstance
-    register_builder(MongoMockBuilder)
+    from .mongomock import MongoMockInstance
+    register_instance(MongoMockInstance)
 except ImportError:  # pragma: no cover
     pass

--- a/umongo/frameworks/mongomock.py
+++ b/umongo/frameworks/mongomock.py
@@ -22,13 +22,13 @@ class MongoMockDocument(PyMongoDocument):
 class MongoMockBuilder(PyMongoBuilder):
     BASE_DOCUMENT_CLS = MongoMockDocument
 
-    @staticmethod
-    def is_compatible_with(db):
-        return isinstance(db, Database)
-
 
 class MongoMockInstance(LazyLoaderInstance):
     """
     :class:`umongo.instance.LazyLoaderInstance` implementation for mongomock
     """
     BUILDER_CLS = MongoMockBuilder
+
+    @staticmethod
+    def is_compatible_with(db):
+        return isinstance(db, Database)

--- a/umongo/frameworks/mongomock.py
+++ b/umongo/frameworks/mongomock.py
@@ -2,6 +2,7 @@ from mongomock.database import Database
 from mongomock.collection import Cursor
 
 from .pymongo import PyMongoBuilder, PyMongoDocument, BaseWrappedCursor
+from ..instance import LazyLoaderInstance
 from ..document import DocumentImplementation
 
 
@@ -24,3 +25,10 @@ class MongoMockBuilder(PyMongoBuilder):
     @staticmethod
     def is_compatible_with(db):
         return isinstance(db, Database)
+
+
+class MongoMockInstance(LazyLoaderInstance):
+    """
+    :class:`umongo.instance.LazyLoaderInstance` implementation for mongomock
+    """
+    BUILDER_CLS = MongoMockBuilder

--- a/umongo/frameworks/mongomock.py
+++ b/umongo/frameworks/mongomock.py
@@ -2,7 +2,7 @@ from mongomock.database import Database
 from mongomock.collection import Cursor
 
 from .pymongo import PyMongoBuilder, PyMongoDocument, BaseWrappedCursor
-from ..instance import LazyLoaderInstance
+from ..instance import Instance
 from ..document import DocumentImplementation
 
 
@@ -23,9 +23,9 @@ class MongoMockBuilder(PyMongoBuilder):
     BASE_DOCUMENT_CLS = MongoMockDocument
 
 
-class MongoMockInstance(LazyLoaderInstance):
+class MongoMockInstance(Instance):
     """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for mongomock
+    :class:`umongo.instance.Instance` implementation for mongomock
     """
     BUILDER_CLS = MongoMockBuilder
 

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -6,7 +6,7 @@ from pymongo.errors import DuplicateKeyError
 import marshmallow as ma
 
 from ..builder import BaseBuilder
-from ..instance import LazyLoaderInstance
+from ..instance import Instance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
@@ -395,9 +395,9 @@ class MotorAsyncIOBuilder(BaseBuilder):
             field.io_validate_recursive = _embedded_document_io_validate
 
 
-class MotorAsyncIOInstance(LazyLoaderInstance):
+class MotorAsyncIOInstance(Instance):
     """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for motor-asyncio
+    :class:`umongo.instance.Instance` implementation for motor-asyncio
     """
     BUILDER_CLS = MotorAsyncIOBuilder
 

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -371,10 +371,6 @@ class MotorAsyncIOBuilder(BaseBuilder):
 
     BASE_DOCUMENT_CLS = MotorAsyncIODocument
 
-    @staticmethod
-    def is_compatible_with(db):
-        return isinstance(db, AsyncIOMotorDatabase)
-
     def _patch_field(self, field):
         super()._patch_field(field)
 
@@ -404,3 +400,7 @@ class MotorAsyncIOInstance(LazyLoaderInstance):
     :class:`umongo.instance.LazyLoaderInstance` implementation for motor-asyncio
     """
     BUILDER_CLS = MotorAsyncIOBuilder
+
+    @staticmethod
+    def is_compatible_with(db):
+        return isinstance(db, AsyncIOMotorDatabase)

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -6,6 +6,7 @@ from pymongo.errors import DuplicateKeyError
 import marshmallow as ma
 
 from ..builder import BaseBuilder
+from ..instance import LazyLoaderInstance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
@@ -396,3 +397,10 @@ class MotorAsyncIOBuilder(BaseBuilder):
             field.reference_cls = MotorAsyncIOReference
         if isinstance(field, EmbeddedField):
             field.io_validate_recursive = _embedded_document_io_validate
+
+
+class MotorAsyncIOInstance(LazyLoaderInstance):
+    """
+    :class:`umongo.instance.LazyLoaderInstance` implementation for motor-asyncio
+    """
+    BUILDER_CLS = MotorAsyncIOBuilder

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -4,6 +4,7 @@ from pymongo.errors import DuplicateKeyError
 import marshmallow as ma
 
 from ..builder import BaseBuilder
+from ..instance import LazyLoaderInstance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
@@ -329,3 +330,10 @@ class PyMongoBuilder(BaseBuilder):
             field.reference_cls = PyMongoReference
         if isinstance(field, EmbeddedField):
             field.io_validate_recursive = _embedded_document_io_validate
+
+
+class PyMongoInstance(LazyLoaderInstance):
+    """
+    :class:`umongo.instance.LazyLoaderInstance` implementation for pymongo
+    """
+    BUILDER_CLS = PyMongoBuilder

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -4,7 +4,7 @@ from pymongo.errors import DuplicateKeyError
 import marshmallow as ma
 
 from ..builder import BaseBuilder
-from ..instance import LazyLoaderInstance
+from ..instance import Instance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
@@ -328,9 +328,9 @@ class PyMongoBuilder(BaseBuilder):
             field.io_validate_recursive = _embedded_document_io_validate
 
 
-class PyMongoInstance(LazyLoaderInstance):
+class PyMongoInstance(Instance):
     """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for pymongo
+    :class:`umongo.instance.Instance` implementation for pymongo
     """
     BUILDER_CLS = PyMongoBuilder
 

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -308,10 +308,6 @@ class PyMongoBuilder(BaseBuilder):
 
     BASE_DOCUMENT_CLS = PyMongoDocument
 
-    @staticmethod
-    def is_compatible_with(db):
-        return isinstance(db, Database)
-
     def _patch_field(self, field):
         super()._patch_field(field)
 
@@ -337,3 +333,7 @@ class PyMongoInstance(LazyLoaderInstance):
     :class:`umongo.instance.LazyLoaderInstance` implementation for pymongo
     """
     BUILDER_CLS = PyMongoBuilder
+
+    @staticmethod
+    def is_compatible_with(db):
+        return isinstance(db, Database)

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -6,6 +6,7 @@ from pymongo.errors import DuplicateKeyError
 import marshmallow as ma
 
 from ..builder import BaseBuilder
+from ..instance import LazyLoaderInstance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
@@ -341,3 +342,10 @@ class TxMongoBuilder(BaseBuilder):
             field.reference_cls = TxMongoReference
         if isinstance(field, EmbeddedField):
             field.io_validate_recursive = _embedded_document_io_validate
+
+
+class TxMongoInstance(LazyLoaderInstance):
+    """
+    :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo
+    """
+    BUILDER_CLS = TxMongoBuilder

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -319,10 +319,6 @@ class TxMongoBuilder(BaseBuilder):
 
     BASE_DOCUMENT_CLS = TxMongoDocument
 
-    @staticmethod
-    def is_compatible_with(db):
-        return isinstance(db, Database)
-
     def _patch_field(self, field):
         super()._patch_field(field)
 
@@ -349,3 +345,7 @@ class TxMongoInstance(LazyLoaderInstance):
     :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo
     """
     BUILDER_CLS = TxMongoBuilder
+
+    @staticmethod
+    def is_compatible_with(db):
+        return isinstance(db, Database)

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -6,7 +6,7 @@ from pymongo.errors import DuplicateKeyError
 import marshmallow as ma
 
 from ..builder import BaseBuilder
-from ..instance import LazyLoaderInstance
+from ..instance import Instance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
@@ -340,9 +340,9 @@ class TxMongoBuilder(BaseBuilder):
             field.io_validate_recursive = _embedded_document_io_validate
 
 
-class TxMongoInstance(LazyLoaderInstance):
+class TxMongoInstance(Instance):
     """
-    :class:`umongo.instance.LazyLoaderInstance` implementation for txmongo
+    :class:`umongo.instance.Instance` implementation for txmongo
     """
     BUILDER_CLS = TxMongoBuilder
 

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -45,7 +45,7 @@ class Instance(abc.ABC):
         from .frameworks import find_instance_from_db
         instance_cls = find_instance_from_db(db)
         instance = instance_cls()
-        instance.init(db)
+        instance.set_db(db)
         return instance
 
     def retrieve_document(self, name_or_template):
@@ -134,14 +134,14 @@ class Instance(abc.ABC):
     @property
     def db(self):
         if not self._db:
-            raise NoDBDefinedError('init must be called to define a db')
+            raise NoDBDefinedError('db not set, please call set_db')
         return self._db
 
     @abc.abstractmethod
     def is_compatible_with(self, db):
         return NotImplemented
 
-    def init(self, db):
+    def set_db(self, db):
         """
         Set the database to use whithin this instance.
 

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -132,11 +132,16 @@ class Instance(BaseInstance):
     the provided database.
     """
 
+    @classmethod
+    def from_db(cls, db):
+        from .frameworks import find_instance_from_db
+        instance_cls = find_instance_from_db(db)
+        instance = instance_cls()
+        instance.init(db)
+        return instance
+
     def __init__(self, db):
         self._db = db
-        # Dynamically find a builder compatible with the db
-        from .frameworks import find_builder_from_db
-        self.BUILDER_CLS = find_builder_from_db(db)
         super().__init__()
 
     @property
@@ -164,6 +169,9 @@ class LazyLoaderInstance(BaseInstance):
             raise NoDBDefinedError('init must be called to define a db')
         return self._db
 
+    def is_compatible_with(self, db):
+        return NotImplemented
+
     def init(self, db):
         """
         Set the database to use whithin this instance.
@@ -172,5 +180,5 @@ class LazyLoaderInstance(BaseInstance):
             The documents registered in the instance cannot be used
             before this function is called.
         """
-        assert self.BUILDER_CLS.is_compatible_with(db)
+        assert self.is_compatible_with(db)
         self._db = db

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -30,14 +30,12 @@ class BaseInstance:
 
     BUILDER_CLS = None
 
-    def __init__(self, templates=()):
+    def __init__(self):
         assert self.BUILDER_CLS, 'BUILDER_CLS must be defined.'
         self.builder = self.BUILDER_CLS(self)
         self._doc_lookup = {}
         self._embedded_lookup = {}
         self._mixin_lookup = {}
-        for template in templates:
-            self.register(template)
 
     @property
     def db(self):
@@ -134,12 +132,12 @@ class Instance(BaseInstance):
     the provided database.
     """
 
-    def __init__(self, db, templates=()):
+    def __init__(self, db):
         self._db = db
         # Dynamically find a builder compatible with the db
         from .frameworks import find_builder_from_db
         self.BUILDER_CLS = find_builder_from_db(db)
-        super().__init__(templates=templates)
+        super().__init__()
 
     @property
     def db(self):
@@ -156,9 +154,9 @@ class LazyLoaderInstance(BaseInstance):
 
     """
 
-    def __init__(self, templates=()):
+    def __init__(self):
         self._db = None
-        super().__init__(templates=templates)
+        super().__init__()
 
     @property
     def db(self):

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -128,10 +128,12 @@ class BaseInstance:
 
 class Instance(BaseInstance):
     """
-    Automatically configured instance according to the type of
-    the provided database.
-    """
+    Base class for instance
 
+    .. note::
+        This class should not be used directly but instead overloaded.
+        See :class:`umongo.PyMongoInstance` for example.
+    """
     @classmethod
     def from_db(cls, db):
         from .frameworks import find_instance_from_db
@@ -140,28 +142,11 @@ class Instance(BaseInstance):
         instance.init(db)
         return instance
 
-    def __init__(self, db):
+    def __init__(self, db=None):
+        super().__init__()
         self._db = db
-        super().__init__()
-
-    @property
-    def db(self):
-        return self._db
-
-
-class LazyLoaderInstance(BaseInstance):
-    """
-    Base class for instance with database lazy loading.
-
-    .. note::
-        This class should not be used directly but instead overloaded.
-        See :class:`umongo.PyMongoInstance` for example.
-
-    """
-
-    def __init__(self):
-        self._db = None
-        super().__init__()
+        if db is not None:
+            self.init(db)
 
     @property
     def db(self):


### PR DESCRIPTION
Remove `templates` argument to `BaseInstance` (undocumented and untested).
Merge `BaseInstance`, `Instance` and `LazyLoaderInstance` into `Instance`.
Make `Instance` an abstract base class.
Rename `Instance.init` into `Instance.set_db`.
Don't expose framework instances in `umongo` top module. They must be imported from `umongo.frameworks`.


Before this change, one could use `Instance(db)` and get the right builder class, but not the right instance class, which works fine because there is no specific method in each framework instance class (for now).

After this change, one must pick a specific framework instance or explicitly call the factory method `Instance.from_db`.

The use case of registering documents then setting the db didn't work before the change because one would either call `Instance(db)` or pick the dedicated framework instance. The only difference between the two is that the latter allows to pass the db object after registering documents. But still, the instance type must be defined.

I'm keeping the `Instance.from_db` factory method in case it is useful to anyone, but I don't really see the use case. Since the db object exists, the user probably knows what framework he is using, so he could pick the right framework instance himself.

Lazy loading still works: one can instantiate a framework specific instance, register documents, and then call `set_db` to actually pass a DB connection. Typical use case, the flask app factory: load all model code and register all documents in the instance at import time, then in app init, set a DB connection.