### PR TITLE
Fix instance init with db as parameter

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -72,7 +72,7 @@ register_instance(MockedInstance)
 class BaseTest:
 
     def setup(self):
-        self.instance = Instance.from_db(MockedDB('my_moked_db'))
+        self.instance = MockedInstance(MockedDB('my_moked_db'))
 
 
 class BaseDBTest:

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -38,7 +38,7 @@ class Instance(abc.ABC):
         self._mixin_lookup = {}
         self._db = db
         if db is not None:
-            self.init(db)
+            self.set_db(db)
 
     @classmethod
     def from_db(cls, db):


### PR DESCRIPTION
Fixes an issue introduced in #314 preventing from doing

```py
instance = PyMongoInstance(db)
```

Only lazy registration would work

```py
instance = PyMongoInstance()
instance.set_db(db)
```

Modifies a test config to use the first form, as a non-reg test.