### PR TITLE
Add migration instance classes

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -12,6 +12,7 @@ Contents:
    :maxdepth: 2
 
    userguide
+   migration
    apireference
    contributing
    authors

--- a/docs/migration.rst
+++ b/docs/migration.rst
@@ -1,0 +1,85 @@
+.. _migration:
+
+=========
+Migrating
+=========
+
+Migrating from umongo 2 to umongo 3
+===================================
+
+For a full list of changes, see the CHANGELOG.
+
+Database migration
+------------------
+
+Aside from changes in application code, migrating from umongo 2 to umongo 3
+requires changes in the database.
+
+The way the embedded documents are stored has changed. The `_cls` attribute is
+now only set on embedded documents that are subclasses of a concrete embedded
+document. Unless documents are non-strict (i.e. transparently handle unknown
+fields, default is strict), the database must be migrated to remove the `_cls`
+fields on embedded documents that are not subclasses of a concrete document.
+
+This change is irreversible. It requires the knowledge of the application model
+(the document and embedded document classes).
+
+umongo provides dedicated framework specific ``Instance`` subclasses to help on
+this.
+
+A simple procedure to build a migration tool is to replace one's ``Instance``
+class in the application code with such class and call
+``instance.migrate_2_to_3`` on init.
+
+For instance, given following umongo 3 application code
+
+.. code-block:: python
+
+    from umongo.frameworks.pymongo import PyMongoInstance
+
+    instance = PyMongoInstance()
+
+    # Register embedded documents
+    [...]
+
+    @instance.register
+    class Doc(Document):
+        name = fields.StrField()
+        # Embed documents
+        embedded = fields.EmbeddedField([...])
+
+    instance.set_db(pymongo.MongoClient())
+
+    # This may raise an exception if Doc contains embedded documents
+    # as described above
+    Doc.find()
+
+the migration can be performed by calling migrate_2_to_3.
+
+.. code-block:: python
+
+    from umongo.frameworks.pymongo import PyMongoMigrationInstance
+
+    instance = PyMongoMigrationInstance()
+
+    # Register embedded documents
+    [...]
+
+    @instance.register
+    class Doc(Document):
+        name = fields.StrField()
+        # Embed documents
+        embedded = fields.EmbeddedField([...])
+
+    instance.set_db(pymongo.MongoClient())
+    instance.migrate_2_to_3()
+
+    # This is safe now that the database is migrated
+    Doc.find()
+
+Of course, this needs to be done only once. Although the migration is
+idempotent, it wouldn't make sense to keep this in the codebase and execute the
+migration on every application startup.
+
+However, it is possible to embed the migration feature in the application code
+by defining a dedicated command, like a Flask CLI command for instance.

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -928,3 +928,75 @@ class TestTxMongo(BaseDBTest):
         callbacks.clear()
         yield p.delete()
         assert callbacks == ['pre_delete', 'post_delete']
+
+    @pytest_inlineCallbacks
+    def test_2_to_3_migration(self, db):
+
+        instance = framework.TxMongoMigrationInstance(db)
+
+        @instance.register
+        class AbstractEmbeddedDoc(EmbeddedDocument):
+            f = fields.StringField()
+
+            class Meta:
+                abstract = True
+
+        @instance.register
+        class ConcreteEmbeddedDoc(AbstractEmbeddedDoc):
+            pass
+
+        @instance.register
+        class ConcreteEmbeddedDocChild(ConcreteEmbeddedDoc):
+            pass
+
+        @instance.register
+        class AbstractDoc(Document):
+
+            class Meta:
+                abstract = True
+
+        @instance.register
+        class Doc(AbstractDoc):
+            ec = fields.EmbeddedField(ConcreteEmbeddedDoc)
+            ecc = fields.EmbeddedField(ConcreteEmbeddedDocChild)
+
+        @instance.register
+        class DocChild(Doc):
+            cec = fields.EmbeddedField(ConcreteEmbeddedDoc)
+            cecc = fields.EmbeddedField(ConcreteEmbeddedDocChild)
+
+        doc_umongo_2 = {
+            "ec": {"f": "Hello", "_cls": "ConcreteEmbeddedDoc"},
+            "ecc": {"f": "Hi", "_cls": "ConcreteEmbeddedDocChild"},
+        }
+        child_doc_umongo_2 = {
+            "_cls": "DocChild",
+            "ec": {"f": "Hello", "_cls": "ConcreteEmbeddedDoc"},
+            "ecc": {"f": "Hi", "_cls": "ConcreteEmbeddedDocChild"},
+            "cec": {"f": "Hello", "_cls": "ConcreteEmbeddedDoc"},
+            "cecc": {"f": "Hi", "_cls": "ConcreteEmbeddedDocChild"},
+        }
+
+        doc_umongo_3 = {
+            "ec": {"f": "Hello"},
+            "ecc": {"f": "Hi", "_cls": "ConcreteEmbeddedDocChild"},
+        }
+        child_doc_umongo_3 = {
+            "_cls": "DocChild",
+            "ec": {"f": "Hello"},
+            "ecc": {"f": "Hi", "_cls": "ConcreteEmbeddedDocChild"},
+            "cec": {"f": "Hello"},
+            "cecc": {"f": "Hi", "_cls": "ConcreteEmbeddedDocChild"},
+        }
+
+        res = yield instance.db.doc.insert_one(doc_umongo_2)
+        doc_umongo_3['_id'] = res.inserted_id
+        res = yield instance.db.doc.insert_one(child_doc_umongo_2)
+        child_doc_umongo_3['_id'] = res.inserted_id
+
+        yield instance.migrate_2_to_3()
+
+        res = yield instance.db.doc.find_one(doc_umongo_3['_id'])
+        assert res == doc_umongo_3
+        res = yield instance.db.doc.find_one(child_doc_umongo_3['_id'])
+        assert res == child_doc_umongo_3

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -424,3 +424,39 @@ class MotorAsyncIOInstance(Instance):
                 yield session
             finally:
                 SESSION.reset(token)
+
+
+class MotorAsyncIOMigrationInstance(MotorAsyncIOInstance):
+    """AsyncIO instance with migration features"""
+
+    async def migrate_2_to_3(self):
+        """Migrate database from umongo 2 to umongo 3
+
+        - EmbeddedDocument _cls field is only set if child of concrete embedded document
+        """
+        concrete_not_children = [
+            name for name, ed in self._embedded_lookup.items()
+            if not ed.opts.is_child and not ed.opts.abstract
+        ]
+
+        def remove_cls_field(json_input):
+            if isinstance(json_input, dict):
+                return {
+                    k: remove_cls_field(v)
+                    for k, v in json_input.items()
+                    if k != "_cls" or v not in concrete_not_children
+                }
+            if isinstance(json_input, list):
+                return [remove_cls_field(item) for item in json_input]
+            return json_input
+
+        for doc_cls in self._doc_lookup.values():
+            if doc_cls.opts.abstract:
+                continue
+            if doc_cls.opts.is_child:
+                continue
+            async for doc in doc_cls.collection.find():
+                doc = remove_cls_field(doc)
+                ret = await doc_cls.collection.replace_one({"_id": doc["_id"]}, doc)
+                if ret.matched_count != 1:
+                    raise UpdateError(ret)

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -16,7 +16,7 @@ from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenc
 from ..fields import ReferenceField, ListField, EmbeddedField
 from ..query_mapper import map_query
 
-from .tools import cook_find_filter
+from .tools import cook_find_filter, remove_cls_field_from_embedded_docs
 
 
 SESSION = ContextVar("session", default=None)
@@ -439,24 +439,13 @@ class MotorAsyncIOMigrationInstance(MotorAsyncIOInstance):
             if not ed.opts.is_child and not ed.opts.abstract
         ]
 
-        def remove_cls_field(json_input):
-            if isinstance(json_input, dict):
-                return {
-                    k: remove_cls_field(v)
-                    for k, v in json_input.items()
-                    if k != "_cls" or v not in concrete_not_children
-                }
-            if isinstance(json_input, list):
-                return [remove_cls_field(item) for item in json_input]
-            return json_input
-
         for doc_cls in self._doc_lookup.values():
             if doc_cls.opts.abstract:
                 continue
             if doc_cls.opts.is_child:
                 continue
             async for doc in doc_cls.collection.find():
-                doc = remove_cls_field(doc)
+                doc = remove_cls_field_from_embedded_docs(doc, concrete_not_children)
                 ret = await doc_cls.collection.replace_one({"_id": doc["_id"]}, doc)
                 if ret.matched_count != 1:
                     raise UpdateError(ret)

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -14,7 +14,7 @@ from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenc
 from ..fields import ReferenceField, ListField, EmbeddedField
 from ..query_mapper import map_query
 
-from .tools import cook_find_filter
+from .tools import cook_find_filter, remove_cls_field_from_embedded_docs
 
 
 SESSION = ContextVar("session", default=None)
@@ -367,24 +367,13 @@ class PyMongoMigrationInstance(PyMongoInstance):
             if not ed.opts.is_child and not ed.opts.abstract
         ]
 
-        def remove_cls_field(json_input):
-            if isinstance(json_input, dict):
-                return {
-                    k: remove_cls_field(v)
-                    for k, v in json_input.items()
-                    if k != "_cls" or v not in concrete_not_children
-                }
-            if isinstance(json_input, list):
-                return [remove_cls_field(item) for item in json_input]
-            return json_input
-
         for doc_cls in self._doc_lookup.values():
             if doc_cls.opts.abstract:
                 continue
             if doc_cls.opts.is_child:
                 continue
             for doc in doc_cls.collection.find():
-                doc = remove_cls_field(doc)
+                doc = remove_cls_field_from_embedded_docs(doc, concrete_not_children)
                 ret = doc_cls.collection.replace_one({"_id": doc["_id"]}, doc)
                 if ret.matched_count != 1:
                     raise UpdateError(ret)

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -9,7 +9,6 @@ import marshmallow as ma
 from ..builder import BaseBuilder
 from ..instance import Instance
 from ..document import DocumentImplementation
-from ..data_proxy import data_proxy_factory
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
 from ..fields import ReferenceField, ListField, EmbeddedField
@@ -363,31 +362,29 @@ class PyMongoMigrationInstance(PyMongoInstance):
 
         - EmbeddedDocument _cls field is only set if child of concrete embedded document
         """
-        not_children = {
-            name: ed for name, ed in self._embedded_lookup.items()
-            if not ed.opts.is_child
-        }
+        concrete_not_children = [
+            name for name, ed in self._embedded_lookup.items()
+            if not ed.opts.is_child and not ed.opts.abstract
+        ]
 
-        # Force "not strict" to accept unexpected _cls field
-        for name, edoc in not_children.items():
-            schema = edoc.schema
-            new_data_proxy = data_proxy_factory(name, schema, False)
-            edoc.DataProxy = new_data_proxy
+        def remove_cls_field(json_input):
+            if isinstance(json_input, dict):
+                return {
+                    k: remove_cls_field(v)
+                    for k, v in json_input.items()
+                    if k != "_cls" or v not in concrete_not_children
+                }
+            if isinstance(json_input, list):
+                return [remove_cls_field(item) for item in json_input]
+            return json_input
 
-        def remove_cls_field(doc):
-            doc_cls = doc.__class__
-            if doc_cls in not_children.values():
-                doc._data._additional_data.pop('_cls', None)
-            for name, field in doc_cls.schema.fields.items():
-                if isinstance(field, EmbeddedField):
-                    if doc[name] is not None:
-                        remove_cls_field(doc[name])
-
-        for name, doc_cls in self._doc_lookup.items():
+        for doc_cls in self._doc_lookup.values():
             if doc_cls.opts.abstract:
                 continue
             if doc_cls.opts.is_child:
                 continue
-            for doc in doc_cls.find():
-                remove_cls_field(doc)
-                doc.commit(replace=True)
+            for doc in doc_cls.collection.find():
+                doc = remove_cls_field(doc)
+                ret = doc_cls.collection.replace_one({"_id": doc["_id"]}, doc)
+                if ret.matched_count != 1:
+                    raise UpdateError(ret)

--- a/umongo/frameworks/tools.py
+++ b/umongo/frameworks/tools.py
@@ -22,3 +22,27 @@ def cook_find_filter(doc_cls, filter):
         else:
             filter['_cls'] = doc_cls.__name__
     return filter
+
+
+def remove_cls_field_from_embedded_docs(dict_in, embedded_docs):
+    """Recursively remove _cls field from nested embedded documents
+
+    This is meant to be used in umongo 2 to 3 migration. The embedded_docs list
+    should be the list of concrete embedded documents that are not subclasses
+    of a concrete document.
+
+    :param dict dict_in: Input document content (dump)
+    :param list embedded_docs: List of embedded documents for which to remove _cls
+    """
+    if isinstance(dict_in, dict):
+        return {
+            k: remove_cls_field_from_embedded_docs(v, embedded_docs)
+            for k, v in dict_in.items()
+            if k != "_cls" or v not in embedded_docs
+        }
+    if isinstance(dict_in, list):
+        return [
+            remove_cls_field_from_embedded_docs(item, embedded_docs)
+            for item in dict_in
+        ]
+    return dict_in


### PR DESCRIPTION
umogo 3 introduces a change in the way embedded documents are represented in database.

This PR provides instance subclasses that can help a user migrating his DB.

The process is not really automatic, but at least this class is useful to build a simple migration script.

Note that it requires access to the model (umongo classes). In other words, the easiest migration path would be to branch the application code to plug this instance in place of the usual one, call the migration method, then end the application.