### PR TITLE
Fix tests: don't query with field from child class

### DIFF
--- a/tests/frameworks/test_motor_asyncio.py
+++ b/tests/frameworks/test_motor_asyncio.py
@@ -748,8 +748,8 @@ class TestMotorAsyncIO(BaseDBTest):
             assert (await InheritanceSearchChild1Child.count_documents()) == 1
             assert (await InheritanceSearchChild2.count_documents()) == 1
 
-            res = await InheritanceSearchParent.find_one({'sc1f': 1})
-            assert isinstance(res, InheritanceSearchChild1Child)
+            res = await InheritanceSearchParent.find_one({'pf': 2})
+            assert isinstance(res, InheritanceSearchChild2)
 
             cursor = InheritanceSearchParent.find({'pf': 1})
             for r in (await cursor.to_list(length=100)):

--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -586,8 +586,8 @@ class TestPymongo(BaseDBTest):
         assert InheritanceSearchChild1Child.count_documents() == 1
         assert InheritanceSearchChild2.count_documents() == 1
 
-        res = InheritanceSearchParent.find_one({'sc1f': 1})
-        assert isinstance(res, InheritanceSearchChild1Child)
+        res = InheritanceSearchParent.find_one({'pf': 2})
+        assert isinstance(res, InheritanceSearchChild2)
 
         res = InheritanceSearchParent.find({'pf': 1})
         for r in res:

--- a/tests/frameworks/test_txmongo.py
+++ b/tests/frameworks/test_txmongo.py
@@ -681,8 +681,8 @@ class TestTxMongo(BaseDBTest):
         res = yield InheritanceSearchChild2.find()
         assert len(res) == 1
 
-        res = yield InheritanceSearchParent.find_one({'sc1f': 1})
-        assert isinstance(res, InheritanceSearchChild1Child)
+        res = yield InheritanceSearchParent.find_one({'pf': 2})
+        assert isinstance(res, InheritanceSearchChild2)
 
         res = yield InheritanceSearchParent.find({'pf': 1})
         for r in res:


### PR DESCRIPTION
Closes #183.

Querying using a field only defined in a subclass is not something that should be encouraged because the query mapper can't do its job, leaving the user with a raw mongo query which can be unexpected.

It works, but let's not show it in the tests.