### PR TITLE
Postpone embedded document resolution

### DIFF
--- a/docs/userguide.rst
+++ b/docs/userguide.rst
@@ -364,7 +364,7 @@ Inheritance inside the same collection is achieve by adding a ``_cls`` field
     {'cls': 'Child', 'unique_in_parent': 42, 'unique_in_child': 'forty_two'}
     >>> Parent(unique_in_parent=22).dump()
     {'unique_in_parent': 22}
-    >>> [x.document for x in Parent.opts.indexes]
+    >>> [x.document for x in Parent.indexes]
     [{'key': SON([('unique_in_parent', 1)]), 'name': 'unique_in_parent_1', 'sparse': True, 'unique': True}]
 
 .. warning:: You must ``register`` a parent before its child inside a given instance.
@@ -384,7 +384,7 @@ In fields, ``unique`` attribute is implicitly handled by an index:
     >>> @instance.register
     ... class WithUniqueEmail(Document):
     ...     email = fields.StrField(unique=True)
-    >>> [x.document for x in WithUniqueEmail.opts.indexes]
+    >>> [x.document for x in WithUniqueEmail.indexes]
     [{'key': SON([('email', 1)]), 'name': 'email_1', 'sparse': True, 'unique': True}]
     >>> WithUniqueEmail.ensure_indexes()
     >>> WithUniqueEmail().commit()
@@ -404,7 +404,7 @@ For more custom indexes, the ``Meta.indexes`` attribute should be used:
     ...     age = fields.Int()
     ...     class Meta:
     ...         indexes = ('#name', 'age', ('-age', 'name'))
-    >>> [x.document for x in CustomIndexes.opts.indexes]
+    >>> [x.document for x in CustomIndexes.indexes]
     [{'key': SON([('name', 'hashed')]), 'name': 'name_hashed'},
      {'key': SON([('age', 1), ]), 'name': 'age_1'},
      {'key': SON([('age', -1), ('name', 1)]), 'name': 'age_-1_name_1'}
@@ -443,7 +443,7 @@ compounded with the ``_cls``
       ...     unique_in_child = fields.StrField(unique=True)
       ...     class Meta:
       ...         indexes = ['#unique_in_parent']
-      >>> [x.document for x in Child.opts.indexes]
+      >>> [x.document for x in Child.indexes]
       [{'name': 'unique_in_parent_1', 'sparse': True, 'unique': True, 'key': SON([('unique_in_parent', 1)])},
        {'name': 'unique_in_parent_hashed__cls_1', 'key': SON([('unique_in_parent', 'hashed'), ('_cls', 1)])},
        {'name': '_cls_1', 'key': SON([('_cls', 1)])},

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -333,15 +333,20 @@ class TestEmbeddedDocument(BaseTest):
             'in_mongo_a_parent': 1, 'b': 2, 'c': 3, 'd': 4, '_cls': 'ConcreteConcreteGrandChild'}
 
         # Cannot use abstract embedded document in EmbeddedField
+        @self.instance.register
+        class MyDoc(Document):
+            impossible = fields.EmbeddedField(AbstractParent)
+
         with pytest.raises(exceptions.DocumentDefinitionError) as exc:
-            @self.instance.register
-            class MyDoc(Document):
-                impossibru = fields.EmbeddedField(AbstractParent)
+            MyDoc(impossible={"a": 12})
         assert exc.value.args[0] == "EmbeddedField doesn't accept abstract embedded document"
+
+        @self.instance.register
+        class MyOtherDoc(Document):
+            impossible = fields.EmbeddedField(AbstractChild)
+
         with pytest.raises(exceptions.DocumentDefinitionError) as exc:
-            @self.instance.register
-            class MyOtherDoc(Document):
-                impossibru = fields.EmbeddedField(AbstractChild)
+            MyOtherDoc(impossible={"a": 12})
         assert exc.value.args[0] == "EmbeddedField doesn't accept abstract embedded document"
 
     def test_bad_inheritance(self):

--- a/tests/test_indexes.py
+++ b/tests/test_indexes.py
@@ -77,8 +77,9 @@ class TestIndexes(BaseTest):
             class Meta:
                 indexes = ['-first_name']
 
-        assert_indexes(Parent.opts.indexes, [IndexModel([('last_name', ASCENDING)])])
-        assert_indexes(Child.opts.indexes,
+        assert_indexes(Parent.indexes, [IndexModel([('last_name', ASCENDING)])])
+        assert_indexes(
+            Child.indexes,
             [
                 IndexModel([('last_name', ASCENDING)]),
                 IndexModel([('first_name', DESCENDING), ('_cls', ASCENDING)]),
@@ -104,7 +105,8 @@ class TestIndexes(BaseTest):
                     'parent', 'parent.child', 'parent.child.grandchild',
                 ]
 
-        assert_indexes(Doc.opts.indexes,
+        assert_indexes(
+            Doc.indexes,
             [
                 IndexModel([('parent', ASCENDING)]),
                 IndexModel([('parent.child', ASCENDING)]),
@@ -133,4 +135,4 @@ class TestIndexes(BaseTest):
         class Doc(Document):
             field = u_field
 
-        assert_indexes(Doc.opts.indexes, [index])
+        assert_indexes(Doc.indexes, [index])

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -548,7 +548,7 @@ class EmbeddedField(BaseField, ma.fields.Nested):
     def as_marshmallow_field(self):
         # Overwrite default `as_marshmallow_field` to handle nesting
         field_kwargs = self._extract_marshmallow_field_params()
-        nested_ma_schema = self._embedded_document_cls.schema.as_marshmallow_schema()
+        nested_ma_schema = self.embedded_document_cls.schema.as_marshmallow_schema()
         return ma.fields.Nested(nested_ma_schema, **field_kwargs)
 
     def _required_validate(self, value):

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -465,11 +465,12 @@ class EmbeddedField(BaseField, ma.fields.Nested):
         implementing the `embedded_document` attribute.
         """
         if not self._embedded_document_cls:
-            self._embedded_document_cls = self.instance.retrieve_embedded_document(
-                self.embedded_document)
-            if self._embedded_document_cls.opts.abstract:
+            embedded_document_cls = self.instance.retrieve_embedded_document(self.embedded_document)
+            if embedded_document_cls.opts.abstract:
                 raise DocumentDefinitionError(
-                    "EmbeddedField doesn't accept abstract embedded document")
+                    "EmbeddedField doesn't accept abstract embedded document"
+                )
+            self._embedded_document_cls = embedded_document_cls
         return self._embedded_document_cls
 
     def _serialize(self, value, attr, obj):

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -289,7 +289,7 @@ class MotorAsyncIODocument(DocumentImplementation):
         """
         Check&create if needed the Document's indexes in database
         """
-        for index in cls.opts.indexes:
+        for index in cls.indexes:
             kwargs = index.document.copy()
             keys = kwargs.pop('key').items()
             await cls.collection.create_index(keys, session=SESSION.get(), **kwargs)

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -233,8 +233,8 @@ class PyMongoDocument(DocumentImplementation):
         """
         Check&create if needed the Document's indexes in database
         """
-        if cls.opts.indexes:
-            cls.collection.create_indexes(cls.opts.indexes, session=SESSION.get())
+        if cls.indexes:
+            cls.collection.create_indexes(cls.indexes, session=SESSION.get())
 
 
 # Run multiple validators and collect all errors in one

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -209,7 +209,7 @@ class TxMongoDocument(DocumentImplementation):
         """
         Check&create if needed the Document's indexes in database
         """
-        for index in cls.opts.indexes:
+        for index in cls.indexes:
             kwargs = index.document.copy()
             keys = kwargs.pop('key')
             index = qf.sort(keys.items())

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -57,7 +57,7 @@ class Instance(abc.ABC):
             name_or_template = name_or_template.__name__
         if name_or_template not in self._doc_lookup:
             raise NotRegisteredDocumentError(
-                'Unknown document class `%s`' % name_or_template)
+                'Unknown document class "%s"' % name_or_template)
         return self._doc_lookup[name_or_template]
 
     def retrieve_embedded_document(self, name_or_template):
@@ -70,7 +70,7 @@ class Instance(abc.ABC):
             name_or_template = name_or_template.__name__
         if name_or_template not in self._embedded_lookup:
             raise NotRegisteredDocumentError(
-                'Unknown embedded document class `%s`' % name_or_template)
+                'Unknown embedded document class "%s"' % name_or_template)
         return self._embedded_lookup[name_or_template]
 
     def register(self, template):


### PR DESCRIPTION
Closes #79.

Ensure embedded document resolution in `EmbeddedField` occurs lazily so that embedded document can be passed as string.

`indexes` become a `Document` cached class property and should now be accessed as `Doc.indexes` rather than `Doc.opts.indexes`.

A downside of this is that using an unregistered embedded document will only be caught on use and not on document registration, in other words at application runtime rather than init.