### PR TITLE
Make BaseSchema ordered

### DIFF
--- a/tests/common.py
+++ b/tests/common.py
@@ -79,3 +79,8 @@ class BaseDBTest:
 
     def setup(self):
         con.drop_database(TEST_DB)
+
+
+def assert_equal_order(dict_a, dict_b):
+    assert dict_a == dict_b
+    assert list(dict_a.items()) == list(dict_b.items())

--- a/tests/test_embedded_document.py
+++ b/tests/test_embedded_document.py
@@ -387,20 +387,24 @@ class TestEmbeddedDocument(BaseTest):
     def test_equality(self):
         @self.instance.register
         class MyChildEmbeddedDocument(EmbeddedDocument):
-            num = fields.IntField()
+            num_1 = fields.IntField()
+            num_2 = fields.IntField()
 
         @self.instance.register
         class MyParentEmbeddedDocument(EmbeddedDocument):
             embedded = fields.EmbeddedField(MyChildEmbeddedDocument)
 
-        emb_1 = MyParentEmbeddedDocument(embedded={'num': 1})
-        emb_2 = MyParentEmbeddedDocument(embedded={'num': 1})
+        emb_1 = MyParentEmbeddedDocument(embedded={'num_1': 1, 'num_2': 2})
+        emb_2 = MyParentEmbeddedDocument(embedded={'num_1': 1, 'num_2': 2})
         emb_3 = MyParentEmbeddedDocument(embedded={})
         emb_4 = MyParentEmbeddedDocument()
+        emb_5 = MyParentEmbeddedDocument(embedded={'num_2': 2})
+        emb_5["embedded"]["num_1"] = 1
 
         assert emb_1 == emb_2
         assert emb_1 != emb_3
         assert emb_1 != emb_4
+        assert emb_1 == emb_5
         assert emb_1 != None  # noqa: E711 (None comparison)
         assert emb_1 != ma.missing
         assert None != emb_1  # noqa: E711 (None comparison)

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -40,6 +40,10 @@ class TestMarshmallow(BaseTest):
         assert issubclass(ma_schema_cls, ma.Schema)
         assert not issubclass(ma_schema_cls, BaseSchema)
 
+    def test_base_marshmallow_schema(self):
+        ma_schema_cls = self.User.schema.as_marshmallow_schema()
+        assert ma_schema_cls.Meta.ordered
+
     def test_custom_ma_base_schema_cls(self):
 
         # Define custom marshmallow schema base class

--- a/tests/test_query_mapper.py
+++ b/tests/test_query_mapper.py
@@ -5,7 +5,7 @@ from bson import ObjectId
 from umongo import Document, EmbeddedDocument, fields
 from umongo.query_mapper import map_query
 
-from .common import BaseTest
+from .common import BaseTest, assert_equal_order
 
 
 class TestQueryMapper(BaseTest):
@@ -110,10 +110,15 @@ class TestQueryMapper(BaseTest):
         query = map_query({
             'author': Author(name='JRR Tolkien', birthday=dt.datetime(1892, 1, 3))
         }, book_fields)
-        assert isinstance(query['a'], dict)
         assert query == {
             'a': {'name': 'JRR Tolkien', 'b': dt.datetime(1892, 1, 3)}
         }
+        assert isinstance(query['a'], dict)
+        # Check the order is preserved when serializing the embedded document
+        # in the query. This is necessary as MongoDB only matches embedded
+        # documents with same order.
+        expected = {'name': 'JRR Tolkien', 'b': dt.datetime(1892, 1, 3)}
+        assert_equal_order(query["a"], expected)
 
         # Test document in query
         editor = Editor(name='Allen & Unwin')

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -4,13 +4,25 @@ from .exceptions import DocumentDefinitionError
 from .i18n import gettext as _, N_
 
 
-__all__ = ('BaseSchema', 'BaseField', 'BaseValidator', 'BaseDataObject')
+__all__ = (
+    'BaseSchema',
+    'BaseMarshmallowSchema',
+    'BaseField',
+    'BaseValidator',
+    'BaseDataObject'
+)
 
 
 class I18nErrorDict(dict):
     def __getitem__(self, name):
         raw_msg = dict.__getitem__(self, name)
         return _(raw_msg)
+
+
+class BaseMarshmallowSchema(ma.Schema):
+    """Base schema for pure marshmallow schemas"""
+    class Meta:
+        ordered = True
 
 
 class BaseSchema(ma.Schema):
@@ -20,7 +32,7 @@ class BaseSchema(ma.Schema):
     # This class attribute is overriden by the builder upon registration
     # to let the template set the base marshmallow schema class.
     # It may be overriden in Template classes.
-    MA_BASE_SCHEMA_CLS = ma.Schema
+    MA_BASE_SCHEMA_CLS = BaseMarshmallowSchema
 
     class Meta:
         ordered = True

--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -22,6 +22,9 @@ class BaseSchema(ma.Schema):
     # It may be overriden in Template classes.
     MA_BASE_SCHEMA_CLS = ma.Schema
 
+    class Meta:
+        ordered = True
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.error_messages = I18nErrorDict(self.error_messages)

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -84,7 +84,8 @@ class BaseDataProxy:
     def load(self, data):
         # Always use marshmallow partial load to skip required checks
         loaded_data = self.schema.load(data, partial=True)
-        self._data = loaded_data
+        # Cast to dict to ignore field order in comparisons
+        self._data = dict(loaded_data)
         # Map the modified fields list on the the loaded data
         self.clear_modified()
         for key in loaded_data:

--- a/umongo/template.py
+++ b/umongo/template.py
@@ -1,4 +1,4 @@
-import marshmallow as ma
+from .abstract import BaseMarshmallowSchema
 
 
 class MetaTemplate(type):
@@ -21,7 +21,7 @@ class Template(metaclass=MetaTemplate):
     """
     Base class to represent a template.
     """
-    MA_BASE_SCHEMA_CLS = ma.Schema
+    MA_BASE_SCHEMA_CLS = BaseMarshmallowSchema
 
     def __init__(self, *args, **kwargs):
         raise NotImplementedError('Cannot instantiate a template, '


### PR DESCRIPTION
Closes #55. Fixes broken embedded document query.

Might introduce a performance penalty.

We could make the base class customizable and this opt-in but
- it would add complexity
- the embedded doc query would still be broken by default

We could make the base class customizable and this opt-out but
- it would add complexity
- people with a real will against this (because of the perf penalty and because they don't query on embedded docs) can monkey-patch the base class.