### PR TITLE
Centralize MA_BASE_SCHEMA_CLS in Template

### DIFF
--- a/umongo/abstract.py
+++ b/umongo/abstract.py
@@ -17,6 +17,9 @@ class BaseSchema(ma.Schema):
     """
     All schema used in umongo should inherit from this base schema
     """
+    # This class attribute is overriden by the builder upon registration
+    # to let the template set the base marshmallow schema class.
+    # It may be overriden in Template classes.
     MA_BASE_SCHEMA_CLS = ma.Schema
 
     def __init__(self, *args, **kwargs):

--- a/umongo/document.py
+++ b/umongo/document.py
@@ -43,7 +43,6 @@ class DocumentTemplate(Template):
         or `marshmallow.post_dump`) to this class that will be passed
         to the marshmallow schema internally used for this document.
     """
-    MA_BASE_SCHEMA_CLS = ma.Schema
 
 
 Document = DocumentTemplate

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -24,7 +24,6 @@ class EmbeddedDocumentTemplate(Template):
         :class:`umongo.instance.BaseInstance` to obtain it corresponding
         :class:`umongo.embedded_document.EmbeddedDocumentImplementation`.
     """
-    MA_BASE_SCHEMA_CLS = ma.Schema
 
 
 EmbeddedDocument = EmbeddedDocumentTemplate

--- a/umongo/mixin.py
+++ b/umongo/mixin.py
@@ -1,6 +1,4 @@
 """umongo MixinDocument"""
-import marshmallow as ma
-
 from .template import Implementation, Template
 
 __all__ = (
@@ -19,7 +17,6 @@ class MixinDocumentTemplate(Template):
         :class:`umongo.instance.BaseInstance` to obtain it corresponding
         :class:`umongo.mixin.MixinDocumentImplementation`.
     """
-    MA_BASE_SCHEMA_CLS = ma.Schema
 
 
 MixinDocument = MixinDocumentTemplate

--- a/umongo/template.py
+++ b/umongo/template.py
@@ -1,3 +1,6 @@
+import marshmallow as ma
+
+
 class MetaTemplate(type):
 
     def __new__(cls, name, bases, nmspc):
@@ -18,6 +21,8 @@ class Template(metaclass=MetaTemplate):
     """
     Base class to represent a template.
     """
+    MA_BASE_SCHEMA_CLS = ma.Schema
+
     def __init__(self, *args, **kwargs):
         raise NotImplementedError('Cannot instantiate a template, '
                                   'use instance.register result instead.')


### PR DESCRIPTION
Centralize the `MA_BASE_SCHEMA_CLS` in template rather than scattering it in `Document`, `EmbededdDocument` and `Mixin`.

The `MA_BASE_SCHEMA_CLS` class attribute in `BaseSchema` is not used because it is overridden by the builder. I added a comment to hint the user not to override it here but in template classes.