### PR TITLE
Allow Reference to be any kind instead of just ObjectId

### DIFF
--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -329,6 +329,8 @@ class ReferenceField(BaseField, ma_bonus_fields.Reference):
         self._document_cls = None
         self._document_implementation_cls = DocumentImplementation
 
+        self._pk_template = None  # This will be lazily defined at serialization.
+
     @property
     def document_cls(self):
         """


### PR DESCRIPTION
This PR addresses https://github.com/Scille/umongo/issues/116, with the expense of `Reference` not being a subclass of `ObjectId`. `Reference` should be able to be used for other field types such as `StringField`, so I'd argue `Reference` is not a subclass of `SubjectId`. 

pytest is successful except for the test to validate `Reference` being a subclass of `ObjectId`. I haven't not changed the test to discuss this further, but I'd be happy to remove that part if the maintainers agree.

This PR implements mutation of `Reference` type by introducing `_pk_template` variable (https://github.com/jbkoh/umongo/blob/fix-referencefield/umongo/fields.py#L332). It is lazily evaluated at https://github.com/jbkoh/umongo/blob/fix-referencefield/umongo/marshmallow_bonus.py#L45 by inspecting the `document_cls`'s `pk_field`. If `pk_field` is not present at the template, it means that it's a default type, `ObjectId`.

Again, this passes all the tests except `Reference` being `ObjectId` which can be removed, I think.

Please let me know if this is the right direction which we can discuss further. If it's completely out of track, I'll just abandon this one.

Thanks!