### PR TITLE
When an object is already created, and is not replacing, skip all required fields that were not modified.

### DIFF
--- a/tests/frameworks/test_pymongo.py
+++ b/tests/frameworks/test_pymongo.py
@@ -201,6 +201,7 @@ class TestPymongo(BaseDBTest):
         class Dummy(Document):
             required_name = fields.StrField(required=True)
             always_io_fail = fields.IntField(io_validate=io_validate)
+            optional_field = fields.StrField()
 
         with pytest.raises(ma.ValidationError) as exc:
             Dummy().commit()
@@ -215,6 +216,12 @@ class TestPymongo(BaseDBTest):
         with pytest.raises(ma.ValidationError) as exc:
             dummy.commit()
         assert exc.value.messages == {'required_name': ['Missing data for required field.']}
+        # Test update of projected document does not require excluded fields
+        dummy = Dummy(required_name='do_not_fail_on_partial_update')
+        dummy.commit()
+        dummy = Dummy.find_one({'required_name': 'do_not_fail_on_partial_update'}, {'optional_field': 1})
+        dummy.optional_field = 'update me!'
+        dummy.commit()
 
     def test_reference(self, classroom_model):
         teacher = classroom_model.Teacher(name='M. Strickland')

--- a/tests/test_data_proxy.py
+++ b/tests/test_data_proxy.py
@@ -385,6 +385,14 @@ class TestDataProxy(BaseTest):
             'listed': {0: {'required': ['Missing data for required field.']}},
             'dicted': {'a': {'value': {'required': ['Missing data for required field.']}}},
         }
+        # Required validate should filter on modified fields if passed in
+        d.load({})
+        d.required_validate(partial_fields=[])
+        with pytest.raises(ma.ValidationError) as exc:
+            d.required_validate(partial_fields=['required'])
+        assert exc.value.messages == {
+            'required': ['Missing data for required field.']
+        }
 
     def test_unkown_field_in_db(self):
         class MySchema(BaseSchema):

--- a/umongo/data_proxy.py
+++ b/umongo/data_proxy.py
@@ -162,9 +162,11 @@ class BaseDataProxy:
                 else:
                     self._data[mongo_name] = field.missing
 
-    def required_validate(self):
+    def required_validate(self, partial_fields=None):
         errors = {}
         for name, field in self.schema.fields.items():
+            if partial_fields is not None and name not in partial_fields:
+                continue
             value = self._data[field.attribute or name]
             if field.required and value is ma.missing:
                 errors[name] = [_("Missing data for required field.")]

--- a/umongo/embedded_document.py
+++ b/umongo/embedded_document.py
@@ -114,8 +114,8 @@ class EmbeddedDocumentImplementation(Implementation, BaseDataObject):
         """
         self._data.clear_modified()
 
-    def required_validate(self):
-        self._data.required_validate()
+    def required_validate(self, partial_fields=None):
+        self._data.required_validate(partial_fields=partial_fields)
 
     @classmethod
     def build_from_mongo(cls, data, use_cls=True):

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -158,7 +158,7 @@ class MotorAsyncIODocument(DocumentImplementation):
                     additional_filter = await self.__coroutined_pre_update()
                     if additional_filter:
                         query.update(map_query(additional_filter, self.schema.fields))
-                    self.required_validate()
+                    self.required_validate(self._data.get_modified_fields())
                     await self.io_validate(validate_all=io_validate_all)
                     if replace:
                         payload = self._data.to_mongo(update=False)

--- a/umongo/frameworks/pymongo.py
+++ b/umongo/frameworks/pymongo.py
@@ -108,7 +108,7 @@ class PyMongoDocument(DocumentImplementation):
                     additional_filter = self.pre_update()
                     if additional_filter:
                         query.update(map_query(additional_filter, self.schema.fields))
-                    self.required_validate()
+                    self.required_validate(partial_fields=self._data.get_modified_fields())
                     self.io_validate(validate_all=io_validate_all)
                     if replace:
                         payload = self._data.to_mongo(update=False)

--- a/umongo/frameworks/txmongo.py
+++ b/umongo/frameworks/txmongo.py
@@ -64,7 +64,7 @@ class TxMongoDocument(DocumentImplementation):
                     additional_filter = yield maybeDeferred(self.pre_update)
                     if additional_filter:
                         query.update(map_query(additional_filter, self.schema.fields))
-                    self.required_validate()
+                    self.required_validate(self._data.get_modified_fields())
                     yield self.io_validate(validate_all=io_validate_all)
                     if replace:
                         payload = self._data.to_mongo(update=False)


### PR DESCRIPTION
This fixes the issue reported in #346 