### PR TITLE
Improve Motor GenericReference field

### DIFF
--- a/tests/test_fields.py
+++ b/tests/test_fields.py
@@ -772,7 +772,7 @@ class TestFields(BaseTest):
 
         @self.instance.register
         class MyDoc(Document):
-            gref = fields.GenericReferenceField(attribute='in_mongo_gref', allow_none=True)
+            gref = fields.GenericReferenceField(attribute='in_mongo_gref', reference_cls=Reference, allow_none=True)
 
         MySchema = MyDoc.Schema
 

--- a/tests/test_marshmallow.py
+++ b/tests/test_marshmallow.py
@@ -1,5 +1,6 @@
 """Test marshmallow-related features"""
 import datetime as dt
+from umongo.data_objects import Reference
 
 import pytest
 
@@ -317,7 +318,7 @@ class TestMarshmallow(BaseTest):
         class Doc(Document):
             id = fields.ObjectIdField(attribute='_id')
             ref = fields.ReferenceField('Doc')
-            gen_ref = fields.GenericReferenceField()
+            gen_ref = fields.GenericReferenceField(reference_cls=Reference)
 
         for name, field_cls in (
                 ('id', ma_bonus_fields.ObjectId),

--- a/umongo/fields.py
+++ b/umongo/fields.py
@@ -374,7 +374,7 @@ class ReferenceField(BaseField, ma_bonus_fields.Reference):
 
 class GenericReferenceField(BaseField, ma_bonus_fields.GenericReference):
 
-    def __init__(self, *args, reference_cls=Reference, **kwargs):
+    def __init__(self, *args, reference_cls=None, **kwargs):
         super().__init__(*args, **kwargs)
         self.reference_cls = reference_cls
         self._document_implementation_cls = DocumentImplementation

--- a/umongo/frameworks/motor_asyncio.py
+++ b/umongo/frameworks/motor_asyncio.py
@@ -14,7 +14,7 @@ from ..instance import Instance
 from ..document import DocumentImplementation
 from ..data_objects import Reference
 from ..exceptions import NotCreatedError, UpdateError, DeleteError, NoneReferenceError
-from ..fields import ReferenceField, ListField, DictField, EmbeddedField
+from ..fields import ReferenceField, GenericReferenceField, ListField, DictField, EmbeddedField
 from ..query_mapper import map_query
 
 from .tools import cook_find_filter, remove_cls_field_from_embedded_docs
@@ -431,6 +431,10 @@ class MotorAsyncIOBuilder(BaseBuilder):
         if isinstance(field, ReferenceField):
             field.io_validate.append(_reference_io_validate)
             field.reference_cls = MotorAsyncIOReference
+        if isinstance(field, GenericReferenceField):
+            field.io_validate.append(_reference_io_validate)
+            if field.reference_cls is None:
+                field.reference_cls = MotorAsyncIOReference
         if isinstance(field, EmbeddedField):
             field.io_validate_recursive = _embedded_document_io_validate
 


### PR DESCRIPTION
I got a `NotImpletemented` exception when using `.fetch` on a generic reference field. This commit fixes the problem. I have a workaround, by declaring the reference_cls attribute explicitly in my own code, `GenericReferenceField(reference_cls=MotorAsyncIOReference)`, but it seemed like a change I should submit upstream.

I noticed a related issue https://github.com/Scille/umongo/issues/349, so I'm trying to make this commit compatible.

What do you think?