### PR TITLE
Fix issue where pymongo Database raises if bool'd

### DIFF
--- a/umongo/document.py
+++ b/umongo/document.py
@@ -117,7 +117,7 @@ class MetaDocumentImplementation(MetaImplementation):
         """
         if cls.opts.abstract:
             raise NoDBDefinedError('Abstract document has no collection')
-        if not cls.opts.instance.db:
+        if cls.opts.instance.db is None:
             raise NoDBDefinedError('Instance must be initialized first')
         return cls.opts.instance.db[cls.opts.collection_name]
 

--- a/umongo/instance.py
+++ b/umongo/instance.py
@@ -133,7 +133,7 @@ class Instance(abc.ABC):
 
     @property
     def db(self):
-        if not self._db:
+        if self._db is None:
             raise NoDBDefinedError('db not set, please call set_db')
         return self._db
 


### PR DESCRIPTION
Addresses #365 

Now it just checks if the `db` is `None`.

Perhaps there are some edge cases with other database types which _do_ implement `bool`?

If so, we can move this change down to the `PyMongoInstance` subclass, but it would require a little more rework.